### PR TITLE
avoiding id attributes on hidden fields

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -97,7 +97,7 @@ module CloudinaryHelper
       content = []
   
       params.each do |name, value|
-        content << hidden_field_tag(name, value)
+        content << hidden_field_tag(name, value, :id => nil)
       end
   
       content << capture(&block)


### PR DESCRIPTION
these ids can sometimes make html invalid
