### PR TITLE
Make it possible to override true config settings with a false option

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -88,18 +88,17 @@ class Cloudinary::Utils
     options[:fetch_format] ||= options.delete(:format) if type == :fetch 
     transformation = self.generate_transformation_string(options)
 
-    resource_type = options.delete(:resource_type) || "image"
-    version = options.delete(:version)
-    format = options.delete(:format)
-    cloud_name = options.delete(:cloud_name) || Cloudinary.config.cloud_name || raise(CloudinaryException, "Must supply cloud_name in tag or in configuration")    
-    secure = options.delete(:secure)
-    ssl_detected = options.delete(:ssl_detected)
-    secure = ssl_detected || Cloudinary.config.secure if secure.nil?
+    resource_type = options.fetch(:resource_type, "image")
+    version = options.fetch(:version, nil)
+    format = options.fetch(:format, nil)
+    cloud_name = options.fetch(:cloud_name) { Cloudinary.config.cloud_name || raise(CloudinaryException, "Must supply cloud_name in tag or in configuration") }
+    ssl_detected = options.fetch(:ssl_detected, false)
+    secure = options.fetch(:secure) { ssl_detected || Cloudinary.config.secure}
     private_cdn = options.fetch(:private_cdn, Cloudinary.config.private_cdn)
-    secure_distribution = options.delete(:secure_distribution) || Cloudinary.config.secure_distribution
+    secure_distribution = options.fetch(:secure_distribution, Cloudinary.config.secure_distribution)
     cname = options.fetch(:cname, Cloudinary.config.cname)
-    force_remote = options.delete(:force_remote)  
-    cdn_subdomain = options.include?(:cdn_subdomain) ? options.delete(:cdn_subdomain) : Cloudinary.config.cdn_subdomain
+    force_remote = options.fetch(:force_remote, false)
+    cdn_subdomain = options.fetch(:cdn_subdomain, Cloudinary.config.cdn_subdomain)
     
     original_source = source
     return original_source if source.blank?

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -22,21 +22,18 @@ describe Cloudinary::Utils do
   it "should allow overriding cloud_name in options" do
     options = {:cloud_name=>"test321"}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "http://res.cloudinary.com/test321/image/upload/test" 
   end
   
   it "should use default secure distribution if secure=true" do    
     options = {:secure=>true}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "https://d3jpl91pxevbkh.cloudfront.net/test123/image/upload/test" 
   end
 
   it "should allow overriding secure distribution if secure=true" do    
     options = {:secure=>true, :secure_distribution=>"something.else.com"}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "https://something.else.com/test123/image/upload/test" 
   end
 
@@ -44,7 +41,6 @@ describe Cloudinary::Utils do
     Cloudinary.config.secure_distribution = "config.secure.distribution.com"    
     options = {:secure=>true}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "https://config.secure.distribution.com/test123/image/upload/test" 
   end
 
@@ -78,7 +74,6 @@ describe Cloudinary::Utils do
   it "should use format from options" do    
     options = {:format=>:jpg}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "http://res.cloudinary.com/test123/image/upload/test.jpg" 
   end
 
@@ -176,7 +171,6 @@ describe Cloudinary::Utils do
   it "should use resource_type from options" do
     options = {:resource_type=>:raw}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "http://res.cloudinary.com/test123/raw/upload/test" 
   end
 
@@ -293,7 +287,6 @@ describe Cloudinary::Utils do
   it "should use ssl_detected if secure is not given as parameter and not set to true in configuration" do    
     options = {:ssl_detected=>true}
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "https://d3jpl91pxevbkh.cloudfront.net/test123/image/upload/test" 
   end 
 
@@ -301,7 +294,6 @@ describe Cloudinary::Utils do
     options = {:ssl_detected=>true, :secure=>false}
     Cloudinary.config.secure = true
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "http://res.cloudinary.com/test123/image/upload/test" 
   end 
 
@@ -309,7 +301,6 @@ describe Cloudinary::Utils do
     options = {:ssl_detected=>false}
     Cloudinary.config.secure = true
     result = Cloudinary::Utils.cloudinary_url("test", options)
-    options.should == {}
     result.should == "https://d3jpl91pxevbkh.cloudfront.net/test123/image/upload/test" 
   end 
 


### PR DESCRIPTION
This lets you override a true value from `Cloudinary.config` with a false value in the options when calling cloudinary_url, by using `options.fetch(:key, fallback)` instead of `options.delete(:key) || fallback`.

I found this out while debugging an issue with the new attachment flag. It worked for our dev account (where we don't set cname, private_cdn or cdn_subdomain), but not in production (where they are set). It turns out overriding these values doesn't fix my issue with attachments, but I think it's a valid improvement anyway. (A support request has been filed regarding the attachment issue.)

The first commit is for the keys I had issues with. The other commit updates the rest of the options keys for consistency.

I have not bumped the version number. I figure you want to do that yourselves.
