### PR TITLE
Add missing require

### DIFF
--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -1,3 +1,5 @@
+require 'rest_client'
+
 class Cloudinary::Api
   class Error < CloudinaryException; end
   class NotFound < Error; end


### PR DESCRIPTION
I received an error when calling `Cloudinary::Api.resources`:

```
NameError: uninitialized constant Cloudinary::Api::RestClient
  from /Users/manuel/code/cloudinary_gem/lib/cloudinary/api.rb:112:in `call_api'
  from /Users/manuel/code/cloudinary_gem/lib/cloudinary/api.rb:33:in `resources'
```

Adding a `require 'rest_client'` to the top of `lib/cloudinary/api.rb` fixed this for me.
