### PR TITLE
override @publiic_id with self.public_id

### DIFF
--- a/lib/cloudinary/carrier_wave.rb
+++ b/lib/cloudinary/carrier_wave.rb
@@ -76,7 +76,7 @@ module Cloudinary::CarrierWave
   # Otherwise, try to use public_id from the database.
   # Otherwise, generate a new random public_id
   def my_public_id
-    @public_id ||= self.public_id 
+    @public_id = self.public_id 
     @public_id ||= @stored_public_id
     @public_id ||= Cloudinary::Utils.random_public_id
   end


### PR DESCRIPTION
I ran into a situation where my public_id defined in the uploader wasn't being used for the image_urls this fixes it. 
