### PR TITLE
Add support for secure distribution and cdn_subdomain

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -146,13 +146,21 @@ class Cloudinary::Utils
       if secure        
         if secure_distribution.nil? || secure_distribution == Cloudinary::OLD_AKAMAI_SHARED_CDN
           secure_distribution = private_cdn ? "#{cloud_name}-res.cloudinary.com" : Cloudinary::SHARED_CDN
+          subdomain = cdn_subdomain ? "res-#{(Zlib::crc32(source) % 5) + 1}." : ""
+          domain_prefix = private_cdn ? "#{cloud_name}-" : ""
+          domain = cdn_subdomain ? "cloudinary.com" : "res.cloudinary.com"
+          host = cname.blank? ? "#{domain_prefix}#{domain}" : cname
+          secure_distribution = "#{subdomain}#{host}"
         end
         shared_domain ||= secure_distribution == Cloudinary::SHARED_CDN
         prefix = "https://#{secure_distribution}"
       else
         subdomain = cdn_subdomain ? "a#{(Zlib::crc32(source) % 5) + 1}." : ""
-        host = cname.blank? ? "#{private_cdn ? "#{cloud_name}-" : ""}res.cloudinary.com" : cname
-        prefix = "http://#{subdomain}#{host}"
+        domain_prefix = private_cdn ? "#{cloud_name}-" : ""
+        domain = "res.cloudinary.com"
+        host = cname.blank? ? "#{domain_prefix}#{domain}" : cname
+        distribution = "#{subdomain}#{host}"
+        prefix = "http://#{distribution}"
       end
       prefix += "/#{cloud_name}" if shared_domain
     end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -439,4 +439,11 @@ describe Cloudinary::Utils do
       Cloudinary::Utils.cloudinary_url(source).should == "http://res.cloudinary.com/test123/image/upload/#{target}"   
     end      
   end
+
+  it "should use res prefix when subdomain is used with secure connection" do
+    options = {:cdn_subdomain=>true, :secure => true}
+    result = Cloudinary::Utils.cloudinary_url("test", options)
+    options.should == {}
+    result.should == "https://res-2.cloudinary.com/test123/image/upload/test" 
+  end
 end


### PR DESCRIPTION
Based on the [following response](http://support.cloudinary.com/entries/25445341-Subdomain-and-ssl-certificate) from the cloudinary team implemented different scheme for subdomain mapping when using https. 
Allows to avoid certificate errors when accessing images due to lack of second level domain in akamai cloudinary SSL certificate.
