### PR TITLE
Fix wrong exception

### DIFF
--- a/lib/cloudinary/carrier_wave/storage.rb
+++ b/lib/cloudinary/carrier_wave/storage.rb
@@ -5,7 +5,7 @@ class Cloudinary::CarrierWave::Storage < ::CarrierWave::Storage::Abstract
     if uploader.is_main_uploader?
       case file
       when Cloudinary::CarrierWave::PreloadedCloudinaryFile
-        storage_type = uploader.class.storage_type || "upload"
+        storage_type = uploader.class.storage_type.to_s || "upload"
         raise CloudinaryException, "Uploader configured for type #{storage_type} but resource of type #{file.type} given." if storage_type != file.type
         if uploader.public_id && uploader.auto_rename_preloaded?
           @stored_version = file.version


### PR DESCRIPTION
I'm getting this exception : 

CloudinaryException (Uploader configured for type private but resource of type private given.)

from :
./lib/cloudinary/carrier_wave/storage.rb:9:

Because storage_type is a symbol and the type given after the upload is a string.

So let's make sure it is a string.

(If I find some time I will write a test case.)
