### PR TITLE
Use Sprockets::Helpers::RailsHelper conditionally on asset pipeline

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -1,6 +1,6 @@
 require 'digest/md5'
 module CloudinaryHelper
-  if Rails.application.config.assets.enabled
+  if asset_pipeline?
     include Sprockets::Helpers::RailsHelper
   else
     include ActionView::Helpers::AssetTagHelper


### PR DESCRIPTION
Use Sprockets conditionally on asset pipeline so that helpers like image_path and image_url will point to /assets instead of /images.
