### PR TITLE
Enable cdn_subdomain for secure url generation 

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -191,7 +191,7 @@ class Cloudinary::Utils
       shared_domain ||= secure_distribution == Cloudinary::SHARED_CDN
 
       if shared_domain && cdn_subdomain
-        secure_distribution.gsub!('res.', "res-#{(Zlib::crc32(source) % 5) + 1}.")
+        secure_distribution = secure_distribution.gsub('res.', "res-#{(Zlib::crc32(source) % 5) + 1}.")
       end
 
       prefix = "https://#{secure_distribution}"


### PR DESCRIPTION
Implement subdomain cycling according to this response from the Cloudinary team:
http://support.cloudinary.com/entries/25445341-Subdomain-and-ssl-certificate

Similar to https://github.com/cloudinary/cloudinary_gem/pull/87 but this limits subdomain cycling to usage of the shared_domain (res.cloudinary.com).
- Decompose generation of the url prefix into it's own method: `Cloudinary::Utils.unsigned_download_url_prefix`
- If using the shared cloudinary secure domain (res.cloudinary.com) and the cdn_subdomain option is enabled, use Zlib::crc32 on the source to pick a consistently numbered subdomain.
- Update utils_spec.rb to test case where both cdn_subdomain and secure options are enabled.
