### PR TITLE
Add support for conditional processing

### DIFF
--- a/lib/cloudinary/carrier_wave/process.rb
+++ b/lib/cloudinary/carrier_wave/process.rb
@@ -3,48 +3,48 @@ module Cloudinary::CarrierWave
     def make_private
       self.storage_type = :private
     end
-    
+
     def process_all_versions(*args)
       @all_versions ||= Class.new(self)
       @all_versions.process *args
     end
-        
+
     def eager
       process :eager => true
     end
-    
+
     def convert(format)
       process :convert => format
     end
-  
+
     def resize_to_limit(width, height)
       process :resize_to_limit => [width, height]
     end
-  
+
     def resize_to_fit(width, height)
       process :resize_to_fit => [width, height]
     end
-  
+
     def resize_to_fill(width, height, gravity="Center")
       process :resize_to_fill => [width, height, gravity]
     end
-  
+
     def resize_and_pad(width, height, background=:transparent, gravity="Center")
       process :resize_and_pad => [width, height, background, gravity]
-    end    
-  
+    end
+
     def scale(width, height)
       process :scale => [width, height]
-    end    
-  
+    end
+
     def crop(width, height, gravity="Center")
       process :crop => [width, height, gravity]
     end
-  
+
     def cloudinary_transformation(options)
       process :cloudinary_transformation => options
     end
-    
+
     def tags(*tags)
       process :tags=>tags
     end
@@ -54,35 +54,43 @@ module Cloudinary::CarrierWave
     raise CloudinaryException, "conflicting transformation on #{attr} #{value}!=#{hash[attr]}" if hash[attr] && hash[attr] != value
     hash[attr] = value
   end
-  
+
   def transformation
     return @transformation if @transformation
     @transformation = {}
-    self.all_processors.each do
-      |name, args|
+    self.all_processors.each do |name, args, condition|
+
+      if(condition)
+        if condition.respond_to?(:call)
+          next unless condition.call(self, :args => args)
+        else
+          next unless self.send(condition)
+        end
+      end
+
       case name
       when :convert # Do nothing. This is handled by format
-      when :resize_to_limit 
-        set_or_yell(@transformation, :width, args[0])    
+      when :resize_to_limit
+        set_or_yell(@transformation, :width, args[0])
         set_or_yell(@transformation, :height, args[1])
         set_or_yell(@transformation, :crop, :limit)
-      when :resize_to_fit 
-        set_or_yell(@transformation, :width, args[0])    
+      when :resize_to_fit
+        set_or_yell(@transformation, :width, args[0])
         set_or_yell(@transformation, :height, args[1])
         set_or_yell(@transformation, :crop, :fit)
       when :resize_to_fill
-        set_or_yell(@transformation, :width, args[0])    
+        set_or_yell(@transformation, :width, args[0])
         set_or_yell(@transformation, :height, args[1])
         set_or_yell(@transformation, :gravity, args[2].to_s.downcase)
         set_or_yell(@transformation, :crop, :fill)
       when :resize_and_pad
-        set_or_yell(@transformation, :width, args[0])    
+        set_or_yell(@transformation, :width, args[0])
         set_or_yell(@transformation, :height, args[1])
         set_or_yell(@transformation, :background, args[2].to_s.downcase)
         set_or_yell(@transformation, :gravity, args[3].to_s.downcase)
         set_or_yell(@transformation, :crop, :pad)
-      when :scale 
-        set_or_yell(@transformation, :width, args[0])    
+      when :scale
+        set_or_yell(@transformation, :width, args[0])
         set_or_yell(@transformation, :height, args[1])
         set_or_yell(@transformation, :crop, :scale)
       when :crop
@@ -92,28 +100,28 @@ module Cloudinary::CarrierWave
         set_or_yell(@transformation, :crop, :crop)
       when :cloudinary_transformation
         args.each do
-          |attr, value|        
+          |attr, value|
           set_or_yell(@transformation, attr, value)
         end
       else
         if args.blank?
           send(name).each do
-            |attr, value|        
+            |attr, value|
             set_or_yell(@transformation, attr, value)
           end
         end
       end
     end
-    @transformation     
+    @transformation
   end
 
   def all_versions_processors
     all_versions = self.class.instance_variable_get('@all_versions')
-    
+
     all_versions ? all_versions.processors : []
   end
 
-  def all_processors    
+  def all_processors
     (self.is_main_uploader? ? [] : all_versions_processors) + self.class.processors
   end
 
@@ -126,22 +134,22 @@ module Cloudinary::CarrierWave
     raise CloudinaryException, "tags cannot be used in versions." if @tags.present? && self.version_name.present?
     @tags
   end
-  
+
   def format
     format_processor = self.all_processors.find{|processor| processor[0] == :convert}
-    if format_processor 
+    if format_processor
       # Explicit format is given
-      format = Array(format_processor[1]).first 
+      format = Array(format_processor[1]).first
     elsif self.transformation.include?(:format)
       format = self.transformation[:format]
-    elsif self.version_name.present? 
+    elsif self.version_name.present?
       # No local format. The reset should be handled by main uploader
       uploader = self.model.send(self.mounted_as)
       format = uploader.format
     else
       # Try to auto-detect format
       format = Cloudinary::PreloadedFile.split_format(original_filename || "").last
-      format ||= "png" # TODO Default format? 
+      format ||= "png" # TODO Default format?
     end
     format = format.to_s.downcase
     Cloudinary::FORMAT_ALIASES[format] || format


### PR DESCRIPTION
Example:

```
version :small do
  process resize_to_fit: [384, 256], if: :must_fit?
  process resize_to_fill: [384, 256, 'Center'], if: :must_fill?
end
```

**Note**: Carrierwave does support this by default already: https://github.com/carrierwaveuploader/carrierwave/blob/c2ee2e89d3aa447c6b81186be6d627202d33a97f/spec/uploader/processing_spec.rb#L50
The only difference here is that we don't pass the file as done by https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/uploader/processing.rb#L77
