### PR TITLE
Switch to faraday from rest-client

### DIFF
--- a/cloudinary.gemspec
+++ b/cloudinary.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "faraday"
+  s.add_dependency "faraday", "~> 0.9"
   s.add_dependency "aws_cf_signer"
   s.add_development_dependency "rspec"
   s.add_development_dependency "actionpack"

--- a/cloudinary.gemspec
+++ b/cloudinary.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "rest-client"
+  s.add_dependency "faraday"
   s.add_dependency "aws_cf_signer"
   s.add_development_dependency "rspec"
   s.add_development_dependency "actionpack"

--- a/lib/cloudinary.rb
+++ b/lib/cloudinary.rb
@@ -15,16 +15,16 @@ module Cloudinary
   autoload :Downloader, "cloudinary/downloader"
   autoload :Blob, "cloudinary/blob"
   autoload :PreloadedFile, "cloudinary/preloaded_file"
-  autoload :Static, "cloudinary/static"  
-  autoload :CarrierWave, "cloudinary/carrier_wave"  
-  
+  autoload :Static, "cloudinary/static"
+  autoload :CarrierWave, "cloudinary/carrier_wave"
+
   CF_SHARED_CDN = "d3jpl91pxevbkh.cloudfront.net"
   AKAMAI_SHARED_CDN = "res.cloudinary.com"
   OLD_AKAMAI_SHARED_CDN = "cloudinary-a.akamaihd.net"
   SHARED_CDN = AKAMAI_SHARED_CDN
-  
+
   USER_AGENT = "cld-ruby-" + VERSION
-    
+
   FORMAT_ALIASES = {
     "jpeg" => "jpg",
     "jpe" => "jpg",
@@ -32,13 +32,13 @@ module Cloudinary
     "ps" => "eps",
     "ept" => "eps"
   }
-  
+
   @@config = nil
-  
+
   def self.config(new_config=nil)
     first_time = @@config.nil?
     @@config ||= OpenStruct.new((YAML.load(ERB.new(IO.read(config_dir.join("cloudinary.yml"))).result)[config_env] rescue {}))
-        
+
     # Heroku support
     if first_time && ENV["CLOUDINARY_CLOUD_NAME"]
       set_config(
@@ -56,9 +56,9 @@ module Cloudinary
     set_config(new_config) if new_config
     yield(@@config) if block_given?
 
-    @@config    
+    @@config
   end
-  
+
   def self.config_from_url(url)
     @@config ||= OpenStruct.new
     uri = URI.parse(url)
@@ -73,9 +73,9 @@ module Cloudinary
       |param|
       key, value = param.split("=")
       set_config(key=>URI.decode(value))
-    end    
+    end
   end
-  
+
   def self.app_root
     if (defined?(Rails) && Rails.root)
       # Rails 2.2 return String for Rails.root
@@ -86,18 +86,18 @@ module Cloudinary
   end
 
   private
-  
+
   def self.config_env
     return ENV["CLOUDINARY_ENV"] if ENV["CLOUDINARY_ENV"]
     return Rails.env if defined?(Rails)
     nil
   end
-  
+
   def self.config_dir
-    return Pathname.new(ENV["CLOUDINARY_CONFIG_DIR"]) if ENV["CLOUDINARY_CONFIG_DIR"] 
+    return Pathname.new(ENV["CLOUDINARY_CONFIG_DIR"]) if ENV["CLOUDINARY_CONFIG_DIR"]
     self.app_root.join("config")
   end
-  
+
   def self.set_config(new_config)
     new_config.each{|k,v| @@config.send(:"#{k}=", v) if !v.nil?}
   end

--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -1,4 +1,4 @@
-require 'rest_client'
+require 'faraday'
 
 class Cloudinary::Api
   class Error < CloudinaryException; end
@@ -8,25 +8,25 @@ class Cloudinary::Api
   class RateLimited < Error; end
   class BadRequest < Error; end
   class GeneralError < Error; end
-  class AuthorizationRequired < Error; end 
+  class AuthorizationRequired < Error; end
   class Response < Hash
     attr_reader :rate_limit_reset_at, :rate_limit_remaining, :rate_limit_allowed
     def initialize(response)
       self.update(Cloudinary::Api.send(:parse_json_response, response))
       @rate_limit_allowed = response.headers[:x_featureratelimit_limit].to_i
       @rate_limit_reset_at = Time.parse(response.headers[:x_featureratelimit_reset])
-      @rate_limit_remaining = response.headers[:x_featureratelimit_remaining].to_i     
+      @rate_limit_remaining = response.headers[:x_featureratelimit_remaining].to_i
     end
   end
 
   def self.ping(options={})
     call_api(:get, "ping", {}, options)
   end
-  
+
   def self.usage(options={})
     call_api(:get, "usage", {}, options)
   end
-  
+
   def self.resource_types(options={})
     call_api(:get, "resources", {}, options)
   end
@@ -36,35 +36,35 @@ class Cloudinary::Api
     type = options[:type]
     uri = "resources/#{resource_type}"
     uri += "/#{type}" if !type.blank?
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix, :tags, :context, :moderations, :direction, :start_at), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix, :tags, :context, :moderations, :direction, :start_at), options)
   end
-  
+
   def self.resources_by_tag(tag, options={})
     resource_type = options[:resource_type] || "image"
     uri = "resources/#{resource_type}/tags/#{tag}"
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)
   end
-  
+
   def self.resources_by_moderation(kind, status, options={})
     resource_type = options[:resource_type] || "image"
     uri = "resources/#{resource_type}/moderations/#{kind}/#{status}"
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)
   end
-  
+
   def self.resources_by_ids(public_ids, options={})
     resource_type = options[:resource_type] || "image"
     type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
     call_api(:get, uri, only(options, :tags, :context, :moderations).merge(:public_ids => public_ids), options)
   end
-  
+
   def self.resource(public_id, options={})
     resource_type = options[:resource_type] || "image"
     type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}/#{public_id}"
-    call_api(:get, uri, only(options, :colors, :exif, :faces, :image_metadata, :pages, :phash, :coordinates, :max_results), options)      
+    call_api(:get, uri, only(options, :colors, :exif, :faces, :image_metadata, :pages, :phash, :coordinates, :max_results), options)
   end
-  
+
   def self.update(public_id, options={})
     resource_type = options[:resource_type] || "image"
     type = options[:type] || "upload"
@@ -85,57 +85,57 @@ class Cloudinary::Api
     }
     call_api(:post, uri, update_options, options)
   end
-  
+
   def self.delete_resources(public_ids, options={})
     resource_type = options[:resource_type] || "image"
-    type = options[:type] || "upload"    
+    type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
-    call_api(:delete, uri, {:public_ids=>public_ids}.merge(only(options, :keep_original, :invalidate)), options)      
+    call_api(:delete, uri, {:public_ids=>public_ids}.merge(only(options, :keep_original, :invalidate)), options)
   end
 
   def self.delete_resources_by_prefix(prefix, options={})
     resource_type = options[:resource_type] || "image"
-    type = options[:type] || "upload"    
+    type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
-    call_api(:delete, uri, {:prefix=>prefix}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)      
+    call_api(:delete, uri, {:prefix=>prefix}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)
   end
-  
+
   def self.delete_all_resources(options={})
     resource_type = options[:resource_type] || "image"
-    type = options[:type] || "upload"    
+    type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
-    call_api(:delete, uri, {:all=>true}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)      
+    call_api(:delete, uri, {:all=>true}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)
   end
-  
+
   def self.delete_resources_by_tag(tag, options={})
     resource_type = options[:resource_type] || "image"
     uri = "resources/#{resource_type}/tags/#{tag}"
-    call_api(:delete, uri, only(options, :keep_original, :next_cursor, :invalidate), options)    
+    call_api(:delete, uri, only(options, :keep_original, :next_cursor, :invalidate), options)
   end
-  
+
   def self.delete_derived_resources(derived_resource_ids, options={})
     uri = "derived_resources"
-    call_api(:delete, uri, {:derived_resource_ids=>derived_resource_ids}, options)      
+    call_api(:delete, uri, {:derived_resource_ids=>derived_resource_ids}, options)
   end
 
   def self.tags(options={})
     resource_type = options[:resource_type] || "image"
     uri = "tags/#{resource_type}"
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix), options)
   end
-  
+
   def self.transformations(options={})
-    call_api(:get, "transformations", only(options, :next_cursor, :max_results), options)    
+    call_api(:get, "transformations", only(options, :next_cursor, :max_results), options)
   end
 
   def self.transformation(transformation, options={})
-    call_api(:get, "transformations/#{transformation_string(transformation)}", only(options, :max_results), options)    
+    call_api(:get, "transformations/#{transformation_string(transformation)}", only(options, :max_results), options)
   end
-  
+
   def self.delete_transformation(transformation, options={})
-    call_api(:delete, "transformations/#{transformation_string(transformation)}", {}, options)    
+    call_api(:delete, "transformations/#{transformation_string(transformation)}", {}, options)
   end
-  
+
   # updates - supports:
   #   "allowed_for_strict" boolean
   #   "unsafe_update" transformation params - updates a named transformation parameters without regenerating existing images
@@ -144,29 +144,29 @@ class Cloudinary::Api
     params[:unsafe_update] = transformation_string(updates[:unsafe_update]) if updates[:unsafe_update]
     call_api(:put, "transformations/#{transformation_string(transformation)}", params, options)
   end
-  
+
   def self.create_transformation(name, definition, options={})
     call_api(:post, "transformations/#{name}", {:transformation=>transformation_string(definition)}, options)
   end
-  
+
   # upload presets
   def self.upload_presets(options={})
-    call_api(:get, "upload_presets", only(options, :next_cursor, :max_results), options)    
+    call_api(:get, "upload_presets", only(options, :next_cursor, :max_results), options)
   end
 
   def self.upload_preset(name, options={})
     call_api(:get, "upload_presets/#{name}", only(options, :max_results), options)
   end
-  
+
   def self.delete_upload_preset(name, options={})
-    call_api(:delete, "upload_presets/#{name}", {}, options)    
+    call_api(:delete, "upload_presets/#{name}", {}, options)
   end
-  
+
   def self.update_upload_preset(name, options={})
     params = Cloudinary::Uploader.build_upload_params(options)
     call_api(:put, "upload_presets/#{name}", params.merge(only(options, :unsigned, :disallow_public_id)), options)
   end
-  
+
   def self.create_upload_preset(options={})
     params = Cloudinary::Uploader.build_upload_params(options)
     call_api(:post, "upload_presets", params.merge(only(options, :name, :unsigned, :disallow_public_id)), options)
@@ -179,9 +179,9 @@ class Cloudinary::Api
   def self.subfolders(of_folder_path, options={})
     call_api(:get, "folders/#{of_folder_path}", {}, options)
   end
-  
+
   protected
-  
+
   def self.call_api(method, uri, params, options)
     cloudinary = options[:upload_prefix] || Cloudinary.config.upload_prefix || "https://api.cloudinary.com"
     cloud_name = options[:cloud_name] || Cloudinary.config.cloud_name || raise("Must supply cloud_name")
@@ -190,42 +190,49 @@ class Cloudinary::Api
     api_url = [cloudinary, "v1_1", cloud_name, uri].join("/")
     # Add authentication
     api_url.sub!(%r(^(https?://)), "\\1#{api_key}:#{api_secret}@")
-    
-    RestClient::Request.execute(:method => method, :url => api_url, :payload => params.reject{|k, v| v.nil? || v==""}, :timeout=>60, :headers => {"User-Agent" => Cloudinary::USER_AGENT}) do
-      |response, request, tmpresult|
-      return Response.new(response) if response.code == 200
-      exception_class = case response.code
-        when 400 then BadRequest
-        when 401 then AuthorizationRequired
-        when 403 then NotAllowed
-        when 404 then NotFound
-        when 409 then AlreadyExists
-        when 420 then RateLimited
-        when 500 then GeneralError
-        else raise GeneralError.new("Server returned unexpected status code - #{response.code} - #{response.body}")   
-      end
-      json = parse_json_response(response)
-      raise exception_class.new(json["error"]["message"])
-    end    
+
+    conn = Faraday.new(:url => api_url)
+    response = conn.post do |req|
+      req.options.timeout = 60
+      req.method = method
+      req.body = params.reject{|k, v| v.nil? || v==""}
+      req.headers["User-Agent"] = Cloudinary::USER_AGENT
+    end
+
+    return Response.new(response) if response.status == 200
+    exception_class = case response.status
+      when 400 then BadRequest
+      when 401 then AuthorizationRequired
+      when 403 then NotAllowed
+      when 404 then NotFound
+      when 409 then AlreadyExists
+      when 420 then RateLimited
+      when 500 then GeneralError
+      else raise GeneralError.new("Server returned unexpected status code - #{response.status} - #{response.body}")
+    end
+
+    json = parse_json_response(response)
+    raise exception_class.new(json["error"]["message"])
+
   end
-  
+
   def self.parse_json_response(response)
     return Cloudinary::Utils.json_decode(response.body)
   rescue => e
     # Error is parsing json
-    raise GeneralError.new("Error parsing server response (#{response.code}) - #{response.body}. Got - #{e}")
+    raise GeneralError.new("Error parsing server response (#{response.status}) - #{response.body}. Got - #{e}")
   end
-  
+
   def self.only(hash, *keys)
     result = {}
     keys.each do
-      |key| 
+      |key|
       result[key] = hash[key] if hash.include?(key)
       result[key] = hash[key.to_s] if hash.include?(key.to_s)
     end
     result
-  end  
-  
+  end
+
   def self.transformation_string(transformation)
     transformation = transformation.is_a?(String) ? transformation : Cloudinary::Utils.generate_transformation_string(transformation.clone)
   end

--- a/lib/cloudinary/uploader.rb
+++ b/lib/cloudinary/uploader.rb
@@ -122,7 +122,7 @@ class Cloudinary::Uploader
         :upload_id=>options[:upload_id]
       }
       if file.is_a?(Pathname) || !file.respond_to?(:read)
-        params[:file] = File.open(file, "rb")
+        params[:file] = Faraday::UploadIO.new(file.to_s, "application/octet-stream")
       else
         params[:file] = file
       end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -19,7 +19,7 @@ describe Cloudinary::Api do
     @api.delete_upload_preset("api_test_upload_preset3") rescue nil
     @api.delete_upload_preset("api_test_upload_preset4") rescue nil
   end
-  
+
   it "should allow listing resource_types" do
     expect(@api.resource_types()["resource_types"]).to include("image")
   end
@@ -61,7 +61,7 @@ describe Cloudinary::Api do
     expect(resources.map{|resource| resource["tags"]}).to include(["api_test_tag", @timestamp_tag])
     expect(resources.map{|resource| resource["context"]}).to include({"custom" => {"key" => "value"}})
   end
-  
+
   it "should allow listing resources by public ids" do
     resources = @api.resources_by_ids(["api_test", "api_test2"], :tags => true, :context => true)["resources"]
     expect(resources.length).to eq(2)
@@ -69,7 +69,7 @@ describe Cloudinary::Api do
     expect(resources.map{|resource| resource["tags"]}).to include(["api_test_tag", @timestamp_tag])
     expect(resources.map{|resource| resource["context"]}).to include({"custom" => {"key" => "value"}})
   end
-  
+
   it "should allow listing resources by start date", :start_at => true do
     sleep(2)
     start_at = Time.now.to_s
@@ -78,7 +78,7 @@ describe Cloudinary::Api do
     resources = @api.resources(:type=>"upload", :start_at=>start_at, :direction => "asc")["resources"]
     expect(resources.map{|resource| resource["public_id"]}) == [response["public_id"]]
   end
-  
+
   it "should allow listing resources in both directions" do
     asc_resources = @api.resources_by_tag(@timestamp_tag, :type=>"upload", :direction => "asc")["resources"]
     desc_resources = @api.resources_by_tag(@timestamp_tag, :type=>"upload", :direction => "desc")["resources"]
@@ -99,7 +99,7 @@ describe Cloudinary::Api do
     expect(resource["bytes"]).to eq(3381)
     expect(resource["derived"].length).to eq(1)
   end
-  
+
   it "should allow deleting derived resource" do
     Cloudinary::Uploader.upload("spec/logo.png", :public_id=>"api_test3", :eager=>[:width=>101,:crop=>:scale])
     resource = @api.resource("api_test3")
@@ -147,7 +147,7 @@ describe Cloudinary::Api do
     tags = @api.tags(:prefix=>"api_test_no_such_tag")["tags"]
     expect(tags).to be_blank
   end
-  
+
   it "should allow listing transformations" do
     transformation = @api.transformations()["transformations"].find{|transformation| transformation["name"] == "c_scale,w_100"}
     expect(transformation).not_to be_blank
@@ -156,28 +156,28 @@ describe Cloudinary::Api do
 
   it "should allow getting transformation metadata" do
     transformation = @api.transformation("c_scale,w_100")
-    expect(transformation).not_to be_blank  
+    expect(transformation).not_to be_blank
     expect(transformation["info"]).to eq(["crop"=>"scale", "width"=>100]     )
     transformation = @api.transformation("crop"=>"scale", "width"=>100)
-    expect(transformation).not_to be_blank  
+    expect(transformation).not_to be_blank
     expect(transformation["info"]).to eq(["crop"=>"scale", "width"=>100]     )
   end
-  
+
   it "should allow updating transformation allowed_for_strict" do
     @api.update_transformation("c_scale,w_100", :allowed_for_strict=>true)
     transformation = @api.transformation("c_scale,w_100")
-    expect(transformation).not_to be_blank  
+    expect(transformation).not_to be_blank
     expect(transformation["allowed_for_strict"]).to eq(true)
     @api.update_transformation("c_scale,w_100", :allowed_for_strict=>false)
     transformation = @api.transformation("c_scale,w_100")
-    expect(transformation).not_to be_blank  
+    expect(transformation).not_to be_blank
     expect(transformation["allowed_for_strict"]).to eq(false)
   end
 
   it "should allow creating named transformation" do
     @api.create_transformation("api_test_transformation", "crop"=>"scale", "width"=>102)
     transformation = @api.transformation("api_test_transformation")
-    expect(transformation).not_to be_blank  
+    expect(transformation).not_to be_blank
     expect(transformation["allowed_for_strict"]).to eq(true)
     expect(transformation["info"]).to eq(["crop"=>"scale", "width"=>102])
     expect(transformation["used"]).to eq(false)
@@ -188,13 +188,13 @@ describe Cloudinary::Api do
     @api.transformation("api_test_transformation2")
     @api.delete_transformation("api_test_transformation2")
     expect{@api.transformation("api_test_transformation2")}.to raise_error(Cloudinary::Api::NotFound)
-  end  
+  end
 
   it "should allow unsafe update of named transformation" do
     @api.create_transformation("api_test_transformation3", "crop"=>"scale", "width"=>102)
     @api.update_transformation("api_test_transformation3", :unsafe_update=>{"crop"=>"scale", "width"=>103})
     transformation = @api.transformation("api_test_transformation3")
-    expect(transformation).not_to be_blank  
+    expect(transformation).not_to be_blank
     expect(transformation["info"]).to eq(["crop"=>"scale", "width"=>103])
     expect(transformation["used"]).to eq(false)
   end
@@ -204,7 +204,7 @@ describe Cloudinary::Api do
     @api.delete_transformation("c_scale,w_100")
     expect{@api.transformation("c_scale,w_100")}.to raise_error(Cloudinary::Api::NotFound)
   end
-  
+
   it "should allow creating and listing upload_presets", :upload_preset => true do
     @api.create_upload_preset(:name => "api_test_upload_preset", :folder => "folder")
     @api.create_upload_preset(:name => "api_test_upload_preset2", :folder => "folder2")
@@ -214,7 +214,7 @@ describe Cloudinary::Api do
     @api.delete_upload_preset("api_test_upload_preset2")
     @api.delete_upload_preset("api_test_upload_preset3")
   end
-  
+
   it "should allow getting a single upload_preset", :upload_preset => true do
     result = @api.create_upload_preset(:unsigned => true, :folder => "folder", :width => 100, :crop => :scale, :tags => ["a","b","c"], :context => {:a => "b", :c => "d"})
     name = result["name"]
@@ -227,14 +227,14 @@ describe Cloudinary::Api do
     expect(preset["settings"]["tags"]).to eq(["a","b","c"])
     @api.delete_upload_preset(name)
   end
-  
+
   it "should allow deleting upload_presets", :upload_preset => true do
     @api.create_upload_preset(:name => "api_test_upload_preset4", :folder => "folder")
     preset = @api.upload_preset("api_test_upload_preset4")
     @api.delete_upload_preset("api_test_upload_preset4")
     expect{preset = @api.upload_preset("api_test_upload_preset4")}.to raise_error
   end
-  
+
   it "should allow updating upload_presets", :upload_preset => true do
     name = @api.create_upload_preset(:folder => "folder")["name"]
     preset = @api.upload_preset(name)
@@ -245,7 +245,7 @@ describe Cloudinary::Api do
     expect(preset["settings"]).to eq({"folder" => "folder", "colors" => true, "disallow_public_id" => true})
     @api.delete_upload_preset(name)
   end
-  
+
   # this test must be last because it deletes (potentially) all dependent transformations which some tests rely on. Excluded by default.
   it "should allow deleting all resources", :delete_all=>true do
     Cloudinary::Uploader.upload("spec/logo.png", :public_id=>"api_test5", :eager=>[:width=>101,:crop=>:scale])
@@ -257,7 +257,7 @@ describe Cloudinary::Api do
     expect(resource).not_to be_blank
     expect(resource["derived"].length).to eq(0)
   end
-  
+
   it "should support setting manual moderation status" do
     result = Cloudinary::Uploader.upload("spec/logo.png", {:moderation => :manual})
     expect(result["moderation"][0]["status"]).to eq("pending")
@@ -266,27 +266,27 @@ describe Cloudinary::Api do
     expect(api_result["moderation"][0]["status"]).to eq("approved")
     expect(api_result["moderation"][0]["kind"]).to eq("manual")
   end
-    
+
   it "should support requesting raw conversion" do
     result = Cloudinary::Uploader.upload("spec/docx.docx", :resource_type => :raw)
     expect{Cloudinary::Api.update(result["public_id"], {:resource_type => :raw, :raw_convert => :illegal})}.to raise_error(Cloudinary::Api::BadRequest, /^Illegal value|not a valid/)
   end
-  
+
   it "should support requesting categorization" do
     result = Cloudinary::Uploader.upload("spec/logo.png")
     expect{Cloudinary::Api.update(result["public_id"], {:categorization => :illegal})}.to raise_error(Cloudinary::Api::BadRequest, /^Illegal value/)
   end
-  
+
   it "should support requesting detection" do
     result = Cloudinary::Uploader.upload("spec/logo.png")
     expect{Cloudinary::Api.update(result["public_id"], {:detection => :illegal})}.to raise_error(Cloudinary::Api::BadRequest, /^Illegal value/)
   end
-  
+
   it "should support requesting auto_tagging" do
     result = Cloudinary::Uploader.upload("spec/logo.png")
     expect{Cloudinary::Api.update(result["public_id"], {:auto_tagging => 0.5})}.to raise_error(Cloudinary::Api::BadRequest, /^Must use/)
   end
-  
+
   it "should support listing by moderation kind and value" do
     result1 = Cloudinary::Uploader.upload("spec/logo.png", {:moderation => :manual})
     result2 = Cloudinary::Uploader.upload("spec/logo.png", {:moderation => :manual})
@@ -308,7 +308,7 @@ describe Cloudinary::Api do
   end
 
   it "should support listing folders" do
-    pending("For this test to work, 'Auto-create folders' should be enabled in the Upload Settings, " + 
+    pending("For this test to work, 'Auto-create folders' should be enabled in the Upload Settings, " +
             "and the account should be empty of folders. " +
             "Comment out this line if you really want to test it.")
     Cloudinary::Uploader.upload("spec/logo.png", {:public_id => "test_folder1/item"})


### PR DESCRIPTION
We were originally going to use the Cloudinary gem in our rails application, but the dependency on RestClient is a bit of a deal breaker. We would much rather be using Faraday for a few reasons.
1. Significantly better syntax, [see documentation here](http://www.intridea.com/blog/2012/3/12/faraday-one-http-client-to-rule-them-all).
2. Proxy settings in RestClient are stored in global state, so can't be set per-request
3. [SSLv3 issues](https://www.google.com/webhp?q=restclient+sslv3+alert+handshake+failure#q=restclient+sslv3+alert+handshake+failure)

(Sorry for the messy diffs -- looks like my text editor decided to remove trailing whitespace)
