### PR TITLE
Fix image closing tags

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -45,7 +45,7 @@ module CloudinaryHelper
     if source
       image_tag_without_cloudinary(source, options)
     else
-      content_tag 'img', nil, options
+      tag 'img', options
     end
   end
 

--- a/spec/cloudinary_helper_spec.rb
+++ b/spec/cloudinary_helper_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CloudinaryHelper do
     context "responsive_width" do
       let(:options) { {responsive_width: true, cloud_name: "test"} }
       it "should use data-src for responsive_width" do
-        img_tag = html_tag_matcher 'img'
+        img_tag = html_self_closing_tag_matcher 'img'
         expect(input).to match img_tag
         expect(input).to include('class="cld-responsive"')
         expect(input).to include( 'data-src="http://res.cloudinary.com/test/image/upload/c_limit,w_auto/sample.jpg"')
@@ -50,7 +50,7 @@ RSpec.describe CloudinaryHelper do
     context "dpr_auto" do
       let(:options) { {dpr: :auto, cloud_name: "test"} }
       it "should use data-src for dpr auto" do
-        img_tag = html_tag_matcher 'img'
+        img_tag = html_self_closing_tag_matcher 'img'
         expect(input).to match(img_tag)
         expect(input).to include('data-src="http://res.cloudinary.com/test/image/upload/dpr_auto/sample.jpg"')
         expect(input).to include('class="cld-hidpi"')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,6 @@ end
 # Create a regexp with the given tag name.
 # @param [String or Symbol] tag tag name (e.g. `img`)
 # @return [Regexp] the regular expression to match the tag
-def html_tag_matcher( tag)
-  /<#{tag}([\s]+[-[:word:]]+[\s]*\=\s*\"[^\"]*\")*\s*>.*<\s*\/#{tag}\s*>/
+def html_self_closing_tag_matcher(tag)
+  /<#{tag}([\s]+[-[:word:]]+[\s]*\=\s*\"[^\"]*\")*\s*\s*\/>*./
 end


### PR DESCRIPTION
This PR removes unvalid </img> tags

There is a bug in the current version of the Cloudinary gem that occurs when using `dpr` or `responsive` options with the cloudinary image tag helper
```
<%= cl_image_tag 'sample.jpg', dpr: :auto %>
```
outputs
```
<img data-src="http://res.cloudinary.com/demo/image/upload/dpr_auto/sample.jpg" class="cld-hidpi"></img>
```

Images are self closing, and the use of [tag](http://apidock.com/rails/ActionView/Helpers/TagHelper/tag) instead of [content_tag](http://apidock.com/rails/ActionView/Helpers/TagHelper/content_tag) fixes that.