### PR TITLE
Using module instead of class for Cloudinary::Api

### DIFF
--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -1,6 +1,6 @@
 require 'rest_client'
 
-class Cloudinary::Api
+module Cloudinary::Api
   class Error < CloudinaryException; end
   class NotFound < Error; end
   class NotAllowed < Error; end
@@ -8,25 +8,25 @@ class Cloudinary::Api
   class RateLimited < Error; end
   class BadRequest < Error; end
   class GeneralError < Error; end
-  class AuthorizationRequired < Error; end 
+  class AuthorizationRequired < Error; end
   class Response < Hash
     attr_reader :rate_limit_reset_at, :rate_limit_remaining, :rate_limit_allowed
     def initialize(response)
       self.update(Cloudinary::Api.send(:parse_json_response, response))
       @rate_limit_allowed = response.headers[:x_featureratelimit_limit].to_i
       @rate_limit_reset_at = Time.parse(response.headers[:x_featureratelimit_reset])
-      @rate_limit_remaining = response.headers[:x_featureratelimit_remaining].to_i     
+      @rate_limit_remaining = response.headers[:x_featureratelimit_remaining].to_i
     end
   end
 
   def self.ping(options={})
     call_api(:get, "ping", {}, options)
   end
-  
+
   def self.usage(options={})
     call_api(:get, "usage", {}, options)
   end
-  
+
   def self.resource_types(options={})
     call_api(:get, "resources", {}, options)
   end
@@ -36,35 +36,35 @@ class Cloudinary::Api
     type = options[:type]
     uri = "resources/#{resource_type}"
     uri += "/#{type}" if !type.blank?
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix, :tags, :context, :moderations, :direction, :start_at), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix, :tags, :context, :moderations, :direction, :start_at), options)
   end
-  
+
   def self.resources_by_tag(tag, options={})
     resource_type = options[:resource_type] || "image"
     uri = "resources/#{resource_type}/tags/#{tag}"
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)
   end
-  
+
   def self.resources_by_moderation(kind, status, options={})
     resource_type = options[:resource_type] || "image"
     uri = "resources/#{resource_type}/moderations/#{kind}/#{status}"
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :tags, :context, :moderations, :direction), options)
   end
-  
+
   def self.resources_by_ids(public_ids, options={})
     resource_type = options[:resource_type] || "image"
     type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
     call_api(:get, uri, only(options, :tags, :context, :moderations).merge(:public_ids => public_ids), options)
   end
-  
+
   def self.resource(public_id, options={})
     resource_type = options[:resource_type] || "image"
     type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}/#{public_id}"
-    call_api(:get, uri, only(options, :colors, :exif, :faces, :image_metadata, :pages, :phash, :coordinates, :max_results), options)      
+    call_api(:get, uri, only(options, :colors, :exif, :faces, :image_metadata, :pages, :phash, :coordinates, :max_results), options)
   end
-  
+
   def self.update(public_id, options={})
     resource_type = options[:resource_type] || "image"
     type = options[:type] || "upload"
@@ -85,57 +85,57 @@ class Cloudinary::Api
     }
     call_api(:post, uri, update_options, options)
   end
-  
+
   def self.delete_resources(public_ids, options={})
     resource_type = options[:resource_type] || "image"
-    type = options[:type] || "upload"    
+    type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
-    call_api(:delete, uri, {:public_ids=>public_ids}.merge(only(options, :keep_original, :invalidate)), options)      
+    call_api(:delete, uri, {:public_ids=>public_ids}.merge(only(options, :keep_original, :invalidate)), options)
   end
 
   def self.delete_resources_by_prefix(prefix, options={})
     resource_type = options[:resource_type] || "image"
-    type = options[:type] || "upload"    
+    type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
-    call_api(:delete, uri, {:prefix=>prefix}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)      
+    call_api(:delete, uri, {:prefix=>prefix}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)
   end
-  
+
   def self.delete_all_resources(options={})
     resource_type = options[:resource_type] || "image"
-    type = options[:type] || "upload"    
+    type = options[:type] || "upload"
     uri = "resources/#{resource_type}/#{type}"
-    call_api(:delete, uri, {:all=>true}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)      
+    call_api(:delete, uri, {:all=>true}.merge(only(options, :keep_original, :next_cursor, :invalidate)), options)
   end
-  
+
   def self.delete_resources_by_tag(tag, options={})
     resource_type = options[:resource_type] || "image"
     uri = "resources/#{resource_type}/tags/#{tag}"
-    call_api(:delete, uri, only(options, :keep_original, :next_cursor, :invalidate), options)    
+    call_api(:delete, uri, only(options, :keep_original, :next_cursor, :invalidate), options)
   end
-  
+
   def self.delete_derived_resources(derived_resource_ids, options={})
     uri = "derived_resources"
-    call_api(:delete, uri, {:derived_resource_ids=>derived_resource_ids}, options)      
+    call_api(:delete, uri, {:derived_resource_ids=>derived_resource_ids}, options)
   end
 
   def self.tags(options={})
     resource_type = options[:resource_type] || "image"
     uri = "tags/#{resource_type}"
-    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix), options)    
+    call_api(:get, uri, only(options, :next_cursor, :max_results, :prefix), options)
   end
-  
+
   def self.transformations(options={})
-    call_api(:get, "transformations", only(options, :next_cursor, :max_results), options)    
+    call_api(:get, "transformations", only(options, :next_cursor, :max_results), options)
   end
 
   def self.transformation(transformation, options={})
-    call_api(:get, "transformations/#{transformation_string(transformation)}", only(options, :max_results), options)    
+    call_api(:get, "transformations/#{transformation_string(transformation)}", only(options, :max_results), options)
   end
-  
+
   def self.delete_transformation(transformation, options={})
-    call_api(:delete, "transformations/#{transformation_string(transformation)}", {}, options)    
+    call_api(:delete, "transformations/#{transformation_string(transformation)}", {}, options)
   end
-  
+
   # updates - supports:
   #   "allowed_for_strict" boolean
   #   "unsafe_update" transformation params - updates a named transformation parameters without regenerating existing images
@@ -144,29 +144,29 @@ class Cloudinary::Api
     params[:unsafe_update] = transformation_string(updates[:unsafe_update]) if updates[:unsafe_update]
     call_api(:put, "transformations/#{transformation_string(transformation)}", params, options)
   end
-  
+
   def self.create_transformation(name, definition, options={})
     call_api(:post, "transformations/#{name}", {:transformation=>transformation_string(definition)}, options)
   end
-  
+
   # upload presets
   def self.upload_presets(options={})
-    call_api(:get, "upload_presets", only(options, :next_cursor, :max_results), options)    
+    call_api(:get, "upload_presets", only(options, :next_cursor, :max_results), options)
   end
 
   def self.upload_preset(name, options={})
     call_api(:get, "upload_presets/#{name}", only(options, :max_results), options)
   end
-  
+
   def self.delete_upload_preset(name, options={})
-    call_api(:delete, "upload_presets/#{name}", {}, options)    
+    call_api(:delete, "upload_presets/#{name}", {}, options)
   end
-  
+
   def self.update_upload_preset(name, options={})
     params = Cloudinary::Uploader.build_upload_params(options)
     call_api(:put, "upload_presets/#{name}", params.merge(only(options, :unsigned, :disallow_public_id)), options)
   end
-  
+
   def self.create_upload_preset(options={})
     params = Cloudinary::Uploader.build_upload_params(options)
     call_api(:post, "upload_presets", params.merge(only(options, :name, :unsigned, :disallow_public_id)), options)
@@ -179,9 +179,9 @@ class Cloudinary::Api
   def self.subfolders(of_folder_path, options={})
     call_api(:get, "folders/#{of_folder_path}", {}, options)
   end
-  
+
   protected
-  
+
   def self.call_api(method, uri, params, options)
     cloudinary = options[:upload_prefix] || Cloudinary.config.upload_prefix || "https://api.cloudinary.com"
     cloud_name = options[:cloud_name] || Cloudinary.config.cloud_name || raise("Must supply cloud_name")
@@ -191,7 +191,7 @@ class Cloudinary::Api
     api_url = [cloudinary, "v1_1", cloud_name, uri].join("/")
     # Add authentication
     api_url.sub!(%r(^(https?://)), "\\1#{api_key}:#{api_secret}@")
-    
+
     RestClient::Request.execute(:method => method, :url => api_url, :payload => params.reject{|k, v| v.nil? || v==""}, :timeout=> timeout, :headers => {"User-Agent" => Cloudinary::USER_AGENT}) do
       |response, request, tmpresult|
       return Response.new(response) if response.code == 200
@@ -203,30 +203,30 @@ class Cloudinary::Api
         when 409 then AlreadyExists
         when 420 then RateLimited
         when 500 then GeneralError
-        else raise GeneralError.new("Server returned unexpected status code - #{response.code} - #{response.body}")   
+        else raise GeneralError.new("Server returned unexpected status code - #{response.code} - #{response.body}")
       end
       json = parse_json_response(response)
       raise exception_class.new(json["error"]["message"])
-    end    
+    end
   end
-  
+
   def self.parse_json_response(response)
     return Cloudinary::Utils.json_decode(response.body)
   rescue => e
     # Error is parsing json
     raise GeneralError.new("Error parsing server response (#{response.code}) - #{response.body}. Got - #{e}")
   end
-  
+
   def self.only(hash, *keys)
     result = {}
     keys.each do
-      |key| 
+      |key|
       result[key] = hash[key] if hash.include?(key)
       result[key] = hash[key.to_s] if hash.include?(key.to_s)
     end
     result
-  end  
-  
+  end
+
   def self.transformation_string(transformation)
     transformation = transformation.is_a?(String) ? transformation : Cloudinary::Utils.generate_transformation_string(transformation.clone)
   end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -24,12 +24,12 @@ describe Cloudinary::Utils do
   it "should allow overriding cloud_name in options" do
     test_cloudinary_url("test", {:cloud_name=>"test321"}, "http://res.cloudinary.com/test321/image/upload/test", {})
   end
-  
-  it "should use default secure distribution if secure=true" do    
+
+  it "should use default secure distribution if secure=true" do
     test_cloudinary_url("test", {:secure=>true}, "https://res.cloudinary.com/test123/image/upload/test", {})
   end
 
-  it "should allow overriding secure distribution if secure=true" do    
+  it "should allow overriding secure distribution if secure=true" do
     test_cloudinary_url("test", {:secure=>true, :secure_distribution=>"something.else.com"}, "https://something.else.com/test123/image/upload/test", {})
   end
 
@@ -81,7 +81,7 @@ describe Cloudinary::Utils do
     expect{Cloudinary::Utils.cloudinary_url("test", {:url_suffix=>"hello.world", :private_cdn=>true})}.to raise_error(CloudinaryException)
   end
 
-  it "should support url_suffix for private_cdn" do    
+  it "should support url_suffix for private_cdn" do
     test_cloudinary_url("test", {:url_suffix=>"hello", :private_cdn=>true}, "http://test123-res.cloudinary.com/images/test/hello", {})
     test_cloudinary_url("test", {:url_suffix=>"hello", :angle=>0, :private_cdn=>true}, "http://test123-res.cloudinary.com/images/a_0/test/hello", {})
   end
@@ -98,7 +98,7 @@ describe Cloudinary::Utils do
     test_cloudinary_url("test", {:url_suffix=>"hello", :private_cdn=>true, :format=>"jpg", :angle=>0, :sign_url=>true}, "http://test123-res.cloudinary.com/images/#{expected_signture}/a_0/test/hello.jpg", {})
   end
 
-  it "should support url_suffix for raw uploads" do    
+  it "should support url_suffix for raw uploads" do
     test_cloudinary_url("test", {:url_suffix=>"hello", :private_cdn=>true, :resource_type=>:raw}, "http://test123-res.cloudinary.com/files/test/hello", {})
   end
 
@@ -140,11 +140,11 @@ describe Cloudinary::Utils do
   it "should not pass width and height to html in case angle was used" do
     test_cloudinary_url("test", { :width => 100, :height => 100, :crop => :scale, :angle => :auto }, "#{upload_path}/a_auto,c_scale,h_100,w_100/test", {})
   end
-    
+
   it "should use x, y, radius, prefix, gravity and quality from options" do
     test_cloudinary_url("test", { :x => 1, :y => 2, :radius => 3, :gravity => :center, :quality => 0.4, :prefix => "a" }, "#{upload_path}/g_center,p_a,q_0.4,r_3,x_1,y_2/test", {})
   end
-  
+
   it "should support named tranformation" do
     test_cloudinary_url("test", { :transformation => "blip" }, "#{upload_path}/t_blip/test", {})
   end
@@ -161,7 +161,7 @@ describe Cloudinary::Utils do
     test_cloudinary_url("test", { :transformation => [{ :x => 100, :y => 100, :width => 200, :crop => :fill }, { :radius => 10 }], :crop => :crop, :width => 100 }, "#{upload_path}/c_fill,w_200,x_100,y_100/r_10/c_crop,w_100/test", { :width => 100 })
   end
 
-  it "should support array of tranformations" do    
+  it "should support array of tranformations" do
     result = Cloudinary::Utils.generate_transformation_string([{:x=>100, :y=>100, :width=>200, :crop=>:fill}, {:radius=>10}])
     expect(result).to eq("c_fill,w_200,x_100,y_100/r_10")
   end
@@ -190,25 +190,25 @@ describe Cloudinary::Utils do
 
   it "should use allow absolute links to /images" do
     test_cloudinary_url("/images/test", {}, "#{upload_path}/test", {})
-  end 
+  end
 
   it "should use ignore absolute links not to /images" do
     test_cloudinary_url("/js/test", {}, "/js/test", {})
-  end 
+  end
 
   it "should escape fetch urls" do
     test_cloudinary_url("http://blah.com/hello?a=b", { :type => :fetch }, "#{root_path}/image/fetch/http://blah.com/hello%3Fa%3Db", {})
-  end 
+  end
 
   it "should should escape http urls" do
     test_cloudinary_url("http://www.youtube.com/watch?v=d9NF2edxy-M", { :type => :youtube }, "#{root_path}/image/youtube/http://www.youtube.com/watch%3Fv%3Dd9NF2edxy-M", {})
-  end 
+  end
 
   it "should support background" do
     test_cloudinary_url("test", { :background => "red" }, "#{upload_path}/b_red/test", {})
     test_cloudinary_url("test", { :background => "#112233" }, "#{upload_path}/b_rgb:112233/test", {})
   end
-  
+
   it "should support default_image" do
     test_cloudinary_url("test", { :default_image => "default" }, "#{upload_path}/d_default/test", {})
   end
@@ -217,11 +217,11 @@ describe Cloudinary::Utils do
     test_cloudinary_url("test", { :angle => "55" }, "#{upload_path}/a_55/test", {})
     test_cloudinary_url("test", { :angle => ["auto", "55"] }, "#{upload_path}/a_auto.55/test", {})
   end
-  
+
   it "should support format for fetch urls" do
     test_cloudinary_url("http://cloudinary.com/images/logo.png", { :format => "jpg", :type => :fetch }, "#{root_path}/image/fetch/f_jpg/http://cloudinary.com/images/logo.png", {})
   end
-  
+
   it "should support effect" do
     test_cloudinary_url("test", { :effect => "sepia" }, "#{upload_path}/e_sepia/test", {})
   end
@@ -238,26 +238,26 @@ describe Cloudinary::Utils do
     it "should support #{param}" do
       test_cloudinary_url("test", { param => "text:hello" }, "#{upload_path}/#{letter}_text:hello/test", {})
     end
-    
+
     it "should not pass width/height to html for #{param}" do
       test_cloudinary_url("test", { param => "text:hello", :height => 100, :width => 100 }, "#{upload_path}/h_100,#{letter}_text:hello,w_100/test", {})
     end
   end
 
 
-  it "should use ssl_detected if secure is not given as parameter and not set to true in configuration" do    
+  it "should use ssl_detected if secure is not given as parameter and not set to true in configuration" do
     test_cloudinary_url("test", {:ssl_detected=>true}, "https://res.cloudinary.com/test123/image/upload/test", {})
-  end 
+  end
 
-  it "should use secure if given over ssl_detected and configuration" do    
+  it "should use secure if given over ssl_detected and configuration" do
     Cloudinary.config.secure = true
     test_cloudinary_url("test", { :ssl_detected => true, :secure => false }, "#{upload_path}/test", {})
-  end 
+  end
 
-  it "should use secure: true from configuration over ssl_detected" do    
+  it "should use secure: true from configuration over ssl_detected" do
     Cloudinary.config.secure = true
     test_cloudinary_url("test", {:ssl_detected=>false}, "https://res.cloudinary.com/test123/image/upload/test", {})
-  end 
+  end
 
   it "should support extenal cname" do
     test_cloudinary_url("test", {:cname=>"hello.com"}, "http://hello.com/test123/image/upload/test", {})
@@ -266,7 +266,7 @@ describe Cloudinary::Utils do
   it "should support extenal cname with cdn_subdomain on" do
     test_cloudinary_url("test", {:cname=>"hello.com", :cdn_subdomain=>true}, "http://a2.hello.com/test123/image/upload/test", {})
   end
-  
+
   it "should support cdn_subdomain with secure on if using shared_domain" do
     test_cloudinary_url("test", {:secure=>true, :cdn_subdomain=>true}, "https://res-2.cloudinary.com/test123/image/upload/test", {})
   end
@@ -282,14 +282,14 @@ describe Cloudinary::Utils do
   it "should support string param" do
     test_cloudinary_url("test", { "effect" => { "sepia" => 10 } }, "#{upload_path}/e_sepia:10/test", {})
   end
-  
+
   it "should support border" do
     test_cloudinary_url("test", { "border" => { :width => 5 } }, "#{upload_path}/bo_5px_solid_black/test", {})
     test_cloudinary_url("test", { "border" => { :width => 5, :color => "#ffaabbdd" } }, "#{upload_path}/bo_5px_solid_rgb:ffaabbdd/test", {})
     test_cloudinary_url("test", { "border" => "1px_solid_blue" }, "#{upload_path}/bo_1px_solid_blue/test", {})
     test_cloudinary_url("test", { "border" => "2" }, "#{upload_path}/test", { :border => "2" })
   end
-  
+
   it "should support flags" do
     test_cloudinary_url("test", { "flags" => "abc" }, "#{upload_path}/fl_abc/test", {})
     test_cloudinary_url("test", { "flags" => ["abc", "def"] }, "#{upload_path}/fl_abc.def/test", {})
@@ -302,17 +302,17 @@ describe Cloudinary::Utils do
   end
 
   it "build_upload_params canonize booleans" do
-    options = {:backup=>true, :use_filename=>false, :colors=>"true", :exif=>"false", :colors=>:true, 
+    options = {:backup=>true, :use_filename=>false, :colors=>"true", :exif=>"false", :colors=>:true,
                :image_metadata=>:false, :invalidate=>1, :eager_async=>"1"}
     params = Cloudinary::Uploader.build_upload_params(options)
-    expect(Cloudinary::Api.only(params, *options.keys)).to eq(
-      :backup=>1, :use_filename=>0, :colors=>1, :exif=>0, :colors=>1, 
+    expect(Cloudinary::Api.send(:only, params, *options.keys)).to eq(
+      :backup=>1, :use_filename=>0, :colors=>1, :exif=>0, :colors=>1,
                :image_metadata=>0, :invalidate=>1, :eager_async=>1
     )
     expect(Cloudinary::Uploader.build_upload_params(:backup=>nil)[:backup]).to be_nil
     expect(Cloudinary::Uploader.build_upload_params({})[:backup]).to be_nil
   end
-  
+
   it "should add version if public_id contains /" do
     test_cloudinary_url("folder/test", {}, "#{upload_path}/v1/folder/test", {})
     test_cloudinary_url("folder/test", { :version => 123 }, "#{upload_path}/v123/folder/test", {})
@@ -325,13 +325,13 @@ describe Cloudinary::Utils do
   it "should allow to shorted image/upload urls" do
     test_cloudinary_url("test", { :shorten => true }, "#{root_path}/iu/test", {})
   end
-  
+
   it "should allow to use folders in PreloadedFile" do
     signature = Cloudinary::Utils.api_sign_request({:public_id=>"folder/file", :version=>"1234"}, Cloudinary.config.api_secret)
     preloaded = Cloudinary::PreloadedFile.new("image/upload/v1234/folder/file.jpg#" + signature)
     expect(preloaded).to be_valid
   end
-  
+
   it "should escape public_ids" do
     [
       ["a b", "a%20b"],
@@ -343,9 +343,9 @@ describe Cloudinary::Utils do
     ].each do
       |source, target|
       expect(Cloudinary::Utils.cloudinary_url(source)).to eq("#{upload_path}/#{target}")
-    end      
+    end
   end
-  
+
   it "should correctly sign URLs", :signed => true do
     test_cloudinary_url("image.jpg", { :version => 1234, :transformation => { :crop => "crop", :width => 10, :height => 20 }, :sign_url => true }, "#{upload_path}/s--Ai4Znfl3--/c_crop,h_20,w_10/v1234/image.jpg", {})
     test_cloudinary_url("image.jpg", { :version => 1234, :sign_url => true }, "#{upload_path}/s----SjmNDA--/v1234/image.jpg", {})
@@ -360,7 +360,7 @@ describe Cloudinary::Utils do
     test_cloudinary_url("image.jpg", { :transformation => { :crop => "crop", :width => 10, :height => 20 }, :sign_url => true, :sign_version => true }, "#{upload_path}/s--Ai4Znfl3--/c_crop,h_20,w_10/image.jpg", {})
     test_cloudinary_url("http://google.com/path/to/image.png", { :type => "fetch", :version => 1234, :sign_url => true, :sign_version => true }, "#{root_path}/image/fetch/s--_GAUclyB--/v1234/http://google.com/path/to/image.png", {})
   end
-  
+
   it "should correctly sign_request" do
     params = Cloudinary::Utils.sign_request({:public_id=>"folder/file", :version=>"1234"})
     expect(params).to eq(:public_id=>"folder/file", :version=>"1234", :signature=>"7a3349cbb373e4812118d625047ede50b90e7b67", :api_key=>"1234")


### PR DESCRIPTION
Since `Cloudinary::Api` is never initialized and all the methods are called directly on the class, there's no need for it to be class. Changed to module.

Also removed trailing whitespaces.