### PR TITLE
Fix: sync_static doesn't pick up configuration from initializers

### DIFF
--- a/lib/tasks/cloudinary.rake
+++ b/lib/tasks/cloudinary.rake
@@ -1,6 +1,6 @@
 namespace :cloudinary do
   desc "Sync static resources with cloudinary"
-  task :sync_static do
+  task :sync_static => :environment do
     delete_missing = ENV["DELETE_MISSING"] == 'true' || ENV["DELETE_MISSING"] == '1'
     Cloudinary::Static.sync(:delete_missing=>delete_missing)
   end


### PR DESCRIPTION
Ensuring rails environment is loaded as a dependency of running sync_static rake task, so anything initializer that sets up Cloudinary.config takes affect.

This will increase the time it takes for the rake task to load, but is not the end of the world to allow proper configuration to be loaded.