### PR TITLE
accept `remote_headers` argument to `download!` method

### DIFF
--- a/lib/cloudinary/carrier_wave/remote.rb
+++ b/lib/cloudinary/carrier_wave/remote.rb
@@ -1,5 +1,5 @@
 module Cloudinary::CarrierWave
-  def download!(uri)
+  def download!(uri, remote_headers = {})
     return super if !self.cloudinary_should_handle_remote?
     if respond_to?(:process_uri)
       uri = process_uri(uri)


### PR DESCRIPTION
CarrierWave 1.0 passes a `remote_headers` argument to the `download!` method. I don't think Cloudinary needs to do anything with it right now, but the method signature needs to be fixed.

Fixes #221 