### PR TITLE
update download method signature to match newest carrierwave

### DIFF
--- a/lib/cloudinary/carrier_wave/remote.rb
+++ b/lib/cloudinary/carrier_wave/remote.rb
@@ -1,5 +1,5 @@
 module Cloudinary::CarrierWave
-  def download!(uri)
+  def download!(uri, remote_headers={})
     return super if !self.cloudinary_should_handle_remote?
     if respond_to?(:process_uri)
       uri = process_uri(uri)
@@ -17,9 +17,9 @@ module Cloudinary::CarrierWave
       @uri = uri
       @original_filename = filename
     end
-    
+
     def delete
       # Do nothing. This is a virtual file.
     end
   end
-end  
+end


### PR DESCRIPTION
The newer carrierwave signature for `download!` looks like this:

```
def download!(uri, remote_headers = {})
```

This updates cloudinary to accept the param without using it since it doesn't appear necessary.