### PR TITLE
don't normalize negative numbers

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -205,14 +205,14 @@ class Cloudinary::Utils
     end
   end
 
+  EXP_REGEXP = Regexp.new(PREDEFINED_VARS.keys.join("|")+'|('+CONDITIONAL_OPERATORS.keys.reverse.map { |k| Regexp.escape(k) }.join('|')+')(?=[ _])')
+  EXP_REPLACEMENT = PREDEFINED_VARS.merge(CONDITIONAL_OPERATORS)
+
   def self.normalize_expression(expression)
     if expression =~ /^!.+!$/ # quoted string
       expression
     else
-      expression.to_s.gsub(
-        Regexp.new(PREDEFINED_VARS.keys.join("|")+'|('+CONDITIONAL_OPERATORS.keys.reverse.map{|k| Regexp.escape(k)}.join('|')+')(?=[ _])'),
-        PREDEFINED_VARS.merge(CONDITIONAL_OPERATORS)
-      ).gsub(/[ _]+/, "_")
+      expression.to_s.gsub(EXP_REGEXP,EXP_REPLACEMENT).gsub(/[ _]+/, "_")
     end
   end
 

--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -210,7 +210,7 @@ class Cloudinary::Utils
       expression
     else
       expression.to_s.gsub(
-        Regexp.union(*PREDEFINED_VARS.keys, *CONDITIONAL_OPERATORS.keys.reverse),
+        Regexp.new(PREDEFINED_VARS.keys.join("|")+'|('+CONDITIONAL_OPERATORS.keys.reverse.map{|k| Regexp.escape(k)}.join('|')+')(?=[ _])'),
         PREDEFINED_VARS.merge(CONDITIONAL_OPERATORS)
       ).gsub(/[ _]+/, "_")
     end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -386,8 +386,8 @@ describe Cloudinary::Utils do
   end
 
   it "should support effect with hash param" do
-    expect(["test", { :effect => { "sepia" => 10 } }])
-      .to produce_url("#{upload_path}/e_sepia:10/test")
+    expect(["test", { :effect => { "sepia" => -10 } }])
+      .to produce_url("#{upload_path}/e_sepia:-10/test")
             .and empty_options
   end
 


### PR DESCRIPTION
Fixed regex to exclude simple negative numbers when replacing "-" (minus sign) with "sub" operator + test