### PR TITLE
Don't call #match on IO objects in Uploader.upload_large

### DIFF
--- a/lib/cloudinary/uploader.rb
+++ b/lib/cloudinary/uploader.rb
@@ -91,7 +91,7 @@ class Cloudinary::Uploader
       public_id = public_id_or_options
       options   = old_options
     end
-    if file.match(REMOTE_URL_REGEX)
+    if file.is_a?(String) && file.match(REMOTE_URL_REGEX)
       return upload(file, options.merge(:public_id => public_id))
     elsif file.is_a?(Pathname) || !file.respond_to?(:read)
       filename = file


### PR DESCRIPTION
Currently giving IO objects to `Cloudinary::Uploader.upload_large` won't work at all, because it will attempt to call #match on any input given, which will result in a `NoMethodError`. We fix that by calling #match only if we were given a String.

This bug was introduced by this commit: https://github.com/cloudinary/cloudinary_gem/commit/5674d61f7a7750a753f9e26e5f8f20efd9e7c155.