### PR TITLE
load environment when running sync_static task

### DIFF
--- a/lib/tasks/cloudinary.rake
+++ b/lib/tasks/cloudinary.rake
@@ -1,7 +1,7 @@
 unless Rake::Task.task_defined?('cloudinary:sync_static') # prevent double-loading/execution
   namespace :cloudinary do
     desc "Sync static resources with cloudinary"
-    task :sync_static do
+    task :sync_static => :environment do
       delete_missing = ENV['DELETE_MISSING'] == 'true' || ENV['DELETE_MISSING'] == '1'
       Cloudinary::Static.sync(:delete_missing => delete_missing)
     end


### PR DESCRIPTION
This got lost in the addition of syncing non-image assets. Adding back so rails environment is loaded as a dependency.