### PR TITLE
Call .to_h on params to avoid deprecation warning in Rails 5

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -305,7 +305,7 @@ class Cloudinary::Utils
   end
 
   def self.api_string_to_sign(params_to_sign)
-    params_to_sign.map{|k,v| [k.to_s, v.is_a?(Array) ? v.join(",") : v]}.reject{|k,v| v.nil? || v == ""}.sort_by(&:first).map{|k,v| "#{k}=#{v}"}.join("&")
+    params_to_sign.to_h.map{|k,v| [k.to_s, v.is_a?(Array) ? v.join(",") : v]}.reject{|k,v| v.nil? || v == ""}.sort_by(&:first).map{|k,v| "#{k}=#{v}"}.join("&")
   end
 
   def self.api_sign_request(params_to_sign, api_secret)


### PR DESCRIPTION
In Rails 5 `ActionController::Parameters` no longer inherits from `HashWithIndifferentAccess` so calling `.map` on params raises the following deprecation warning:

> DEPRECATION WARNING: Method map is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.6/classes/ActionController/Parameters.html

By the time `params_to_sign` reaches `Cloudinary::Utils.api_string_to_sign()` it doesn't matter if it's parameters or a hash so converting it to a hash resolves the problem and shouldn't cause any other issues.