### PR TITLE
Add accepted_formats to `accept` file upload attribute

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -225,6 +225,7 @@ module CloudinaryHelper
     end
 
     tag_options = html_options.merge(:type=>"file", :name=>"file",
+      :"accept"=>(options[:allowed_formats] || []).collect { |format| format.prepend('.') }.join(','),
       :"data-url"=>cl_upload_url(options),
       :"data-form-data"=>cl_upload_tag_params(options),
       :"data-cloudinary-field"=>field,

--- a/spec/cloudinary_helper_spec.rb
+++ b/spec/cloudinary_helper_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe CloudinaryHelper do
       expect(test_tag['data-cloudinary-field']).to eq('image_id[]')
       expect(test_tag['multiple']).to eq('multiple')
     end
+
+    let(:accepts_tag) { TestTag.new( helper.cl_image_upload_tag('image_id', { accepts_formats: %w{ png jpg } })) }
+    it "Adds the accepted formats via the accept attribute" do
+      expect(accepts_tag['accept']).to eq('.png,.jpg')
+    end
   end
   context "#cl_upload_tag" do
     let(:options) {{:multiple => true}}


### PR DESCRIPTION
This will take the allowed_formats option and convert it into a value
suitable for the `accept` file input attribute, for example:

```
<%= f.cl_image_upload(:avatar, allowed_formats: %w(jpg jpeg gif png)) %>
```

Would output:

```
 <input type="file" name="file"
 accept=".jpg,.jpeg,.gif,.png"
 class="cloudinary-fileupload" />
```