### PR TITLE
namespace resolution for cloudinary controller for avoiding conflicts

### DIFF
--- a/lib/cloudinary.rb
+++ b/lib/cloudinary.rb
@@ -153,7 +153,7 @@ module Cloudinary
 end
   # Prevent require loop if included after Rails is already initialized.
   require "cloudinary/helper" if defined?(::ActionView::Base)
-  require "cloudinary/controller" if defined?(::ActionController::Base)
+  require "cloudinary/cloudinary_controller" if defined?(::ActionController::Base)
   require "cloudinary/railtie" if defined?(Rails) && defined?(Rails::Railtie)
   require "cloudinary/engine" if defined?(Rails) && defined?(Rails::Engine)
 

--- a/lib/cloudinary/cloudinary_controller.rb
+++ b/lib/cloudinary/cloudinary_controller.rb
@@ -1,4 +1,4 @@
-module CloudinaryController
+module Cloudinary::CloudinaryController
   protected
   
   def valid_cloudinary_response?
@@ -10,4 +10,4 @@ module CloudinaryController
   end  
 end
 
-ActionController::Base.send :include, CloudinaryController
+ActionController::Base.send :include, Cloudinary::CloudinaryController


### PR DESCRIPTION
Fix #146, added namespace resolution for cloudinary controller for avoiding conflicts when generating a controller with same name.