### PR TITLE
Support non-path files in upload_large

### DIFF
--- a/lib/cloudinary/uploader.rb
+++ b/lib/cloudinary/uploader.rb
@@ -93,7 +93,9 @@ class Cloudinary::Uploader
       public_id = public_id_or_options
       options   = old_options
     end
-    if file.match(REMOTE_URL_REGEX)
+    if file.respond_to?(:read)
+      filename = file.original_filename
+    elsif file.match(REMOTE_URL_REGEX)
       return upload(file, options.merge(:public_id => public_id))
     elsif file.is_a?(Pathname) || !file.respond_to?(:read)
       filename = file


### PR DESCRIPTION
In an attempt to pass an `ActionDispatch::Http::UploadedFile` as the upload source, invoking `upload_large` currently returns something like:

    NoMethodError (undefined method `match’ for #<ActionDispatch::Http::UploadedFile:0x000055f1b01c9498>)
This fixes this behavior, and will also pass the `original_filename` to the upload_call