### PR TITLE
Fix ruby 2.4 deprecation warning

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -1071,7 +1071,7 @@ class Cloudinary::Utils
 
   def self.process_custom_pre_function(param)
     value = process_custom_function(param)
-    value ? "pre:#{value}" : NIL
+    value ? "pre:#{value}" : nil
   end
 
   def self.process_custom_function(param)


### PR DESCRIPTION
A fix for #329 

AFAIK NIL == nil in all versions of ruby, so there should be no downside. The deprecation warning is
```
lib/cloudinary/utils.rb:1074: warning: constant ::NIL is deprecated
```

Let me know if there is anything I can do to help get this merged.