### PR TITLE
Add jpeg to IMAGE_FORMATS

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -813,7 +813,7 @@ class Cloudinary::Utils
     end
   end
 
-  IMAGE_FORMATS = %w(ai bmp bpg djvu eps eps3 flif gif hdp hpx ico j2k jp2 jpc jpe jpg miff pdf png psd svg tif tiff wdp webp zip )
+  IMAGE_FORMATS = %w(ai bmp bpg djvu eps eps3 flif gif hdp hpx ico j2k jp2 jpc jpe jpeg jpg miff pdf png psd svg tif tiff wdp webp zip )
 
   AUDIO_FORMATS = %w(aac aifc aiff flac m4a mp3 ogg wav)
 


### PR DESCRIPTION
close #280 

`jpeg` was removed by [this commit](https://github.com/cloudinary/cloudinary_gem/commit/65b79c87f0bc2f33fb0c25f8a54d5c67faf8d223) .  

If you have a reason to remove `jpeg`,  please tell me why `jpeg` is removed. ( @diazruy [has already asked same question](https://github.com/cloudinary/cloudinary_gem/commit/65b79c87f0bc2f33fb0c25f8a54d5c67faf8d223#r26772859), but nobody answered it.

Thanks.
