### PR TITLE
Reduce memory usage in Cloudinary::Utils.cloudinary_url

### DIFF
--- a/lib/cloudinary/auth_token.rb
+++ b/lib/cloudinary/auth_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 if RUBY_VERSION > "2"
   require "ostruct"
@@ -10,6 +12,7 @@ module Cloudinary
   module AuthToken
     SEPARATOR = '~'
     UNSAFE = /[ "#%&\'\/:;<=>?@\[\\\]^`{\|}~]/
+    EMPTY_TOKEN = {}.freeze
 
     def self.generate(options = {})
       key = options[:key]
@@ -42,12 +45,11 @@ module Cloudinary
       "#{name}=#{token.join(SEPARATOR)}"
     end
 
-
     # Merge token2 to token1 returning a new
     # Requires to support Ruby 1.9
     def self.merge_auth_token(token1, token2)
-      token1 = token1 || {}
-      token2 = token2 || {}
+      token1 = token1 || EMPTY_TOKEN
+      token2 = token2 || EMPTY_TOKEN
       token1 = token1.respond_to?( :to_h) ? token1.to_h : token1
       token2 = token2.respond_to?( :to_h) ? token2.to_h : token2
       token1.merge(token2)

--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -1,4 +1,6 @@
 # Copyright Cloudinary
+
+# frozen_string_literal: true
 require 'digest/sha1'
 require 'zlib'
 require 'uri'
@@ -41,6 +43,27 @@ class Cloudinary::Utils
     "tags"                 => "tags",
     "width"                => "w"
   }
+
+  TODO_BETTER_NAME = {
+    :ac => :audio_codec,
+    :af => :audio_frequency,
+    :br => :bit_rate,
+    :cs => :color_space,
+    :d  => :default_image,
+    :dl => :delay,
+    :dn => :density,
+    :du => :duration,
+    :eo => :end_offset,
+    :f  => :fetch_format,
+    :g  => :gravity,
+    :ki => :keyframe_interval,
+    :p  => :prefix,
+    :pg => :page,
+    :so => :start_offset,
+    :sp => :streaming_profile,
+    :vc => :video_codec,
+    :vs => :video_sampling
+  }.freeze
 
   URL_KEYS = %w[
       api_secret
@@ -226,26 +249,7 @@ class Cloudinary::Utils
       :y => normalize_expression(options.delete(:y)),
       :z => normalize_expression(options.delete(:zoom))
     }
-    {
-      :ac => :audio_codec,
-      :af => :audio_frequency,
-      :br => :bit_rate,
-      :cs => :color_space,
-      :d  => :default_image,
-      :dl => :delay,
-      :dn => :density,
-      :du => :duration,
-      :eo => :end_offset,
-      :f  => :fetch_format,
-      :g  => :gravity,
-      :ki => :keyframe_interval,
-      :p  => :prefix,
-      :pg => :page,
-      :so => :start_offset,
-      :sp => :streaming_profile,
-      :vc => :video_codec,
-      :vs => :video_sampling
-    }.each do
+    TODO_BETTER_NAME.each do
       |param, option|
       params[param] = options.delete(option)
     end
@@ -307,7 +311,9 @@ class Cloudinary::Utils
   EXP_REPLACEMENT = PREDEFINED_VARS.merge(CONDITIONAL_OPERATORS)
 
   def self.normalize_expression(expression)
-    if expression.is_a?( String) && expression =~ /^!.+!$/ # quoted string
+    if expression.nil?
+      ''
+    elsif expression.is_a?( String) && expression =~ /^!.+!$/ # quoted string
       expression
     else
       expression.to_s.gsub(EXP_REGEXP,EXP_REPLACEMENT).gsub(/[ _]+/, "_")


### PR DESCRIPTION
When generating cloudinary urls via `Cloudinary::Utils.cloudinary_url`, I have noticed a lot of memory usage. I have processes that can generate 100,000s of these urls in background jobs.

For example:
```
options = {:format=>"jpg", :resource_type=>"image", :secure=>false}
public_ids = Array.new(10) { |i| "public#{i}" }

MemoryProfiler.report do
  public_ids.each { |public_id| Cloudinary::Utils.cloudinary_url(public_id, options) }
end.pretty_print
```

Memory Report
```
Total allocated: 95620 bytes (1390 objects)
Total retained:  0 bytes (0 objects)
```

Measuring that same block with Benchmark IPS
```
Warming up --------------------------------------
                       127.000  i/100ms
Calculating -------------------------------------
                          1.296k (±11.0%) i/s -      6.477k in   5.061306s
```

This PR adds `frozen_string_literal: true`, which will improve memory consumption for rubies >= 2.3 but it should be backwards compatible. Also extracted two hash constants. I could use some help naming `TODO_BETTER_NAME`, not sure what this represents.

Running the same with this PR
Memory Report
```
Total allocated: 52980 bytes (642 objects)
Total retained:  40 bytes (1 objects)
```

Benchmark IPS
```
Warming up --------------------------------------
                       157.000  i/100ms
Calculating -------------------------------------
                          1.703k (±13.4%) i/s -      8.321k in   5.003724s
```