### PR TITLE
Adding support for derived_next_cursor to options when listing details of single resource

### DIFF
--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -88,7 +88,8 @@ class Cloudinary::Api
                   :max_results,
                   :pages,
                   :phash,
-                  :quality_analysis
+                  :quality_analysis,
+                  :derived_next_cursor
              ), options)
   end
 

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -37,10 +37,10 @@ describe Cloudinary::Api do
 
   it "should allow using derived_next_cursor when listing details of a single resource" do
     expected = {
-      [:payload, :derived_next_cursor] => "abc"
+      [:payload, :derived_next_cursor] => "b16b8bd80426df43a107f26b0348"
     }
     expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
-    @api.resource("test", {"derived_next_cursor" => "abc"})
+    @api.resource("test", {"derived_next_cursor" => "b16b8bd80426df43a107f26b0348"})
   end
 
   it "should allow listing resource_types" do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -35,6 +35,12 @@ describe Cloudinary::Api do
     end
   end
 
+  it "should allow using derived_next_cursor when listing details of a single resource" do
+    expected_derived_next_cursor = "foo"
+    expect(RestClient::Request).to receive(:execute).with(deep_hash_value([:payload, :derived_next_cursor] => expected_derived_next_cursor))
+    @api.resource("test", { "derived_next_cursor" => "foo"})
+  end
+
   it "should allow listing resource_types" do
     expect(@api.resource_types()["resource_types"]).to include("image")
   end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -36,9 +36,11 @@ describe Cloudinary::Api do
   end
 
   it "should allow using derived_next_cursor when listing details of a single resource" do
-    expected_derived_next_cursor = "foo"
-    expect(RestClient::Request).to receive(:execute).with(deep_hash_value([:payload, :derived_next_cursor] => expected_derived_next_cursor))
-    @api.resource("test", { "derived_next_cursor" => "foo"})
+    expected = {
+      [:payload, :derived_next_cursor] => "abc"
+    }
+    expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
+    @api.resource("test", {"derived_next_cursor" => "abc"})
   end
 
   it "should allow listing resource_types" do


### PR DESCRIPTION
Updated old PR that had failing build and was abandoned 