### PR TITLE
Limit sqlite3 to a compatible version

### DIFF
--- a/samples/photo_album/Gemfile
+++ b/samples/photo_album/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.21'
-gem 'sqlite3'
+gem 'sqlite3', '~>1.3.5'
 gem 'jquery-rails'
 
 gem 'carrierwave'
@@ -16,5 +16,3 @@ gem 'test-unit'
 # Optional - turbolinks support
 #gem 'turbolinks'
 #gem 'jquery-turbolinks'
-
-


### PR DESCRIPTION
ActiveRecord SQLite3 adapter version 3.2 requires requires sqlite3 '~>1.3.5'.