### PR TITLE
Fix active storage download not using ssl for https

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -129,7 +129,7 @@ module ActiveStorage
                     else range.end
                     end
         req['range'] = "bytes=#{[range.begin, range_end].join('-')}"
-        res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
           http.request(req)
         end
         res.body.force_encoding(Encoding::BINARY)

--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -102,12 +102,11 @@ module ActiveStorage
       uri = URI(url)
       if block_given?
         instrument :streaming_download, key: key do
-          Net::HTTP.start(uri.host, uri.port) do |http|
+          Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
             request = Net::HTTP::Get.new uri
             http.request request do |response|
               response.read_body &block
             end
-
           end
         end
       else


### PR DESCRIPTION
There is an error when I upload image to Cloudinary after I set `Cloudinary.config.secure = true` for https url. It is because when ActiveStorage trying to run `ActiveStorage::AnalyzeJob`, it will stream the image from Cloudinary without setting ssl to true.

```2019-11-14T06:52:03.421Z pid=34001 tid=ow0hcp7xh WARN: Errno::ECONNRESET: Connection reset by peer
2019-11-14T06:52:03.421Z pid=34001 tid=ow0hcp7xh WARN: <internal:prelude>:73:in `__read_nonblock'
<internal:prelude>:73:in `read_nonblock'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/protocol.rb:210:in `rbuf_fill'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/protocol.rb:191:in `readuntil'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/protocol.rb:201:in `readline'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http/response.rb:40:in `read_status_line'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http/response.rb:29:in `read_new'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http.rb:1509:in `block in transport_request'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http.rb:1506:in `catch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http.rb:1506:in `transport_request'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http.rb:1479:in `request'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/cloudinary-1.12.0/lib/active_storage/service/cloudinary_service.rb:107:in `block (2 levels) in download'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http.rb:920:in `start'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/2.6.0/net/http.rb:605:in `start'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/cloudinary-1.12.0/lib/active_storage/service/cloudinary_service.rb:105:in `block in download'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `block in instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/service.rb:124:in `instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/cloudinary-1.12.0/lib/active_storage/service/cloudinary_service.rb:104:in `download'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/app/models/active_storage/blob.rb:165:in `download'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/downloading.rb:29:in `download_blob_to'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/downloading.rb:11:in `block in download_blob_to_tempfile'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/downloading.rb:20:in `open_tempfile_for_blob'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/downloading.rb:10:in `download_blob_to_tempfile'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/analyzer/image_analyzer.rb:35:in `read_image'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/lib/active_storage/analyzer/image_analyzer.rb:21:in `metadata'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/app/models/active_storage/blob/analyzable.rb:47:in `extract_metadata_via_analyzer'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/app/models/active_storage/blob/analyzable.rb:29:in `analyze'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activestorage-5.2.3/app/jobs/active_storage/analyze_job.rb:6:in `perform'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/execution.rb:39:in `block in perform_now'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/i18n-1.6.0/lib/i18n.rb:297:in `with_locale'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/translation.rb:9:in `block (2 levels) in <module:Translation>'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/logging.rb:26:in `block (4 levels) in <module:Logging>'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `block in instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `instrument'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/logging.rb:25:in `block (3 levels) in <module:Logging>'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/logging.rb:46:in `block in tag_logger'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `block in tagged'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:28:in `tagged'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `tagged'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/logging.rb:46:in `tag_logger'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/logging.rb:22:in `block (2 levels) in <module:Logging>'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:136:in `run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/execution.rb:38:in `perform_now'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/execution.rb:24:in `block in execute'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/railtie.rb:28:in `block (4 levels) in <class:Railtie>'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/execution_wrapper.rb:87:in `wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/reloader.rb:73:in `block in wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/execution_wrapper.rb:83:in `wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/reloader.rb:72:in `wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/railtie.rb:27:in `block (3 levels) in <class:Railtie>'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:136:in `run_callbacks'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/execution.rb:22:in `execute'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activejob-5.2.3/lib/active_job/queue_adapters/sidekiq_adapter.rb:42:in `perform'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:196:in `execute_job'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:164:in `block (2 levels) in process'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/middleware/chain.rb:138:in `block in invoke'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/bugsnag-6.11.1/lib/bugsnag/integrations/sidekiq.rb:24:in `call'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/middleware/chain.rb:143:in `invoke'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:163:in `block in process'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:136:in `block (6 levels) in dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/job_retry.rb:111:in `local'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:135:in `block (5 levels) in dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/rails.rb:43:in `block in call'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/execution_wrapper.rb:87:in `wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/reloader.rb:73:in `block in wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/execution_wrapper.rb:87:in `wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/reloader.rb:72:in `wrap'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/rails.rb:42:in `call'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:131:in `block (4 levels) in dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:257:in `stats'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:126:in `block (3 levels) in dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/job_logger.rb:13:in `call'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:125:in `block (2 levels) in dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/job_retry.rb:78:in `global'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:124:in `block in dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/logger.rb:10:in `with'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/job_logger.rb:33:in `prepare'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:123:in `dispatch'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:162:in `process'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:78:in `process_one'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/processor.rb:68:in `run'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/util.rb:15:in `watchdog'
/Users/hjchan/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/sidekiq-6.0.3/lib/sidekiq/util.rb:24:in `block in safe_thread'```