### PR TITLE
Fix lingering Rails 6 autoload warnings

### DIFF
--- a/lib/cloudinary/cloudinary_controller.rb
+++ b/lib/cloudinary/cloudinary_controller.rb
@@ -1,13 +1,11 @@
 module Cloudinary::CloudinaryController
   protected
-  
+
   def valid_cloudinary_response?
     received_signature = request.query_parameters[:signature]
     calculated_signature = Cloudinary::Utils.api_sign_request(
       request.query_parameters.select{|key, value| [:public_id, :version].include?(key.to_sym)},
       Cloudinary.config.api_secret)
     return received_signature == calculated_signature
-  end  
+  end
 end
-
-ActionController::Base.send :include, Cloudinary::CloudinaryController

--- a/lib/cloudinary/railtie.rb
+++ b/lib/cloudinary/railtie.rb
@@ -1,8 +1,12 @@
 class Cloudinary::Railtie < Rails::Railtie
   rake_tasks do
     Dir[File.join(File.dirname(__FILE__),'../tasks/*.rake')].each { |f| load f }
-  end  
+  end
   config.after_initialize do |app|
     ActionView::Base.send :include, CloudinaryHelper
+  end
+
+  config.on_load(:action_controller_base) do
+    ActionController::Base.send :include, Cloudinary::CloudinaryController
   end
 end

--- a/lib/cloudinary/railtie.rb
+++ b/lib/cloudinary/railtie.rb
@@ -6,7 +6,7 @@ class Cloudinary::Railtie < Rails::Railtie
     ActionView::Base.send :include, CloudinaryHelper
   end
 
-  config.on_load(:action_controller_base) do
+  ActiveSupport.on_load(:action_controller_base) do
     ActionController::Base.send :include, Cloudinary::CloudinaryController
   end
 end


### PR DESCRIPTION
## Problem

As originally raised in #351, Cloudinary's gem produces deprecation warning for autoloading during initialization. Unfortunately, those warnings are still lingering and will be outright errors in future releases of Rails.

I have [this sample app that reproduces the warnings](https://github.com/wspurgin/vanilla) if you run `rake spec`, you'll see:

```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <top (required)> at /path/to/vanilla/config/environment.rb:5)
```

The problem is from https://github.com/cloudinary/cloudinary_gem/blob/1.13.2/lib/cloudinary/cloudinary_controller.rb#L13 where the `CloudinaryController` module is loaded directly into `ActionController::Base` (regardless of whether its already been loaded or not). This produces the autoloading issue for most apps because the gem is required automatically.

## Solution

Move the `include` into `railties` as part of an [on load hook for `ActionController`](https://guides.rubyonrails.org/engines.html#modifying-code-to-use-on-load-hooks)