### PR TITLE
Make global folder optional in Active Storage

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -147,6 +147,8 @@ module ActiveStorage
     end
 
     def public_id(key)
+      return key unless @options[:folder]
+
       File.join(@options.fetch(:folder), public_id_internal(key))
     end
 


### PR DESCRIPTION
Would be nice if the `folder` option will be not required when we use Active Storage. Or is it a bad idea?