### PR TITLE
Set default cache storage to `file` in `CarrierWave`

### DIFF
--- a/lib/cloudinary/carrier_wave.rb
+++ b/lib/cloudinary/carrier_wave.rb
@@ -9,6 +9,7 @@ module Cloudinary::CarrierWave
 
   def self.included(base)
     base.storage Cloudinary::CarrierWave::Storage
+    base.cache_storage = :file if base.cache_storage.blank?
     base.extend ClassMethods
     base.class_attribute :metadata
     base.class_attribute :storage_type, instance_reader: false

--- a/samples/photo_album/config/initializers/carrierwave.rb
+++ b/samples/photo_album/config/initializers/carrierwave.rb
@@ -1,3 +1,0 @@
-CarrierWave.configure do |config|
-  config.cache_storage = :file
-end


### PR DESCRIPTION
Fixes #344 