### PR TITLE
When normalizing expressions, don't replace variables named liked a predefined variable

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -306,7 +306,7 @@ class Cloudinary::Utils
     "if_" + normalize_expression(if_value) unless if_value.to_s.empty?
   end
 
-  EXP_REGEXP = Regexp.new(PREDEFINED_VARS.keys.join("|")+'|('+CONDITIONAL_OPERATORS.keys.reverse.map { |k| Regexp.escape(k) }.join('|')+')(?=[ _])')
+  EXP_REGEXP = Regexp.new('(?<!\$)('+PREDEFINED_VARS.keys.join("|")+')'+'|('+CONDITIONAL_OPERATORS.keys.reverse.map { |k| Regexp.escape(k) }.join('|')+')(?=[ _])')
   EXP_REPLACEMENT = PREDEFINED_VARS.merge(CONDITIONAL_OPERATORS)
 
   def self.normalize_expression(expression)

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1011,6 +1011,16 @@ describe Cloudinary::Utils do
       expect( ["sample", :crop => "scale", :overlay => {:text => "$(start)Hello $(name)$(ext), $(no ) $( no)$(end)", :font_family => "Arial", :font_size => "18"} ]).to produce_url "#{upload_path}/c_scale,l_text:Arial_18:$(start)Hello%20$(name)$(ext)%252C%20%24%28no%20%29%20%24%28%20no%29$(end)/sample"
 
     end
+
+    it "should not change variable names even if they are keywords" do
+      options = { :transformation => [
+        {"$width" => 10},
+        {:width => "$width + 10 + width"}
+      ] }
+
+      t = Cloudinary::Utils.generate_transformation_string options, true
+      expect(t).to eq("$width_10/w_$width_add_10_add_w")
+    end
   end
 
     describe "context" do


### PR DESCRIPTION
`normalize_expression()` will no longer transform predefined variables into their shortened form if they are preceded by an ampersand (meaning they are variables).

For example: `$width` will not be transformed into `$w`.