### PR TITLE
Integrate with sub-account test service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,8 @@ matrix:
       rvm: ruby-2.5.3
       before_install:
         - gem install bundler
+
+before_script: >
+  export CLOUDINARY_URL=$(bash tools/get_test_cloud.sh);
+  echo cloud_name: "$(echo $CLOUDINARY_URL | cut -d'@' -f2)"
 script: bundle exec rspec

--- a/cloudinary.gemspec
+++ b/cloudinary.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec", '>=3.5'
+  s.add_development_dependency "rspec-retry"
   s.add_development_dependency "rails", "~>5.2" if RUBY_VERSION >= "2.2.2"
 
   s.add_development_dependency "railties", "<= 4.2.7" if RUBY_VERSION <= "1.9.3"

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -497,7 +497,10 @@ describe Cloudinary::Api do
       result = Cloudinary::Uploader.upload TEST_IMG, access_mode: "authenticated", tags: [TEST_TAG, TIMESTAMP_TAG, access_mode_tag]
       publicId = result["public_id"]
       expect(result["access_mode"]).to eq("authenticated")
-      sleep(3)
+    end
+
+    around(:each) do |ex|
+      ex.run_with_retry retry: 3
     end
 
     it "should update access mode by ids" do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -486,7 +486,7 @@ describe Cloudinary::Api do
     end
   end
 
-  describe "access_mode" do
+  describe "access_mode", :with_retries do
     i = 0
 
     publicId = ""
@@ -497,10 +497,6 @@ describe Cloudinary::Api do
       result = Cloudinary::Uploader.upload TEST_IMG, access_mode: "authenticated", tags: [TEST_TAG, TIMESTAMP_TAG, access_mode_tag]
       publicId = result["public_id"]
       expect(result["access_mode"]).to eq("authenticated")
-    end
-
-    around(:each) do |ex|
-      ex.run_with_retry retry: 3
     end
 
     it "should update access mode by ids" do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -497,6 +497,7 @@ describe Cloudinary::Api do
       result = Cloudinary::Uploader.upload TEST_IMG, access_mode: "authenticated", tags: [TEST_TAG, TIMESTAMP_TAG, access_mode_tag]
       publicId = result["public_id"]
       expect(result["access_mode"]).to eq("authenticated")
+      sleep(3)
     end
 
     it "should update access mode by ids" do

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -47,7 +47,7 @@ describe Cloudinary::Search do
     end
   end
 
-  context 'integration' do
+  context 'integration', :with_retries do
     SEARCH_TAG = TIMESTAMP_TAG + "_search"
     include_context 'cleanup', SEARCH_TAG
     prefix = "api_test_#{SUFFIX}"
@@ -59,10 +59,6 @@ describe Cloudinary::Search do
       Cloudinary::Uploader.upload(TEST_IMG, public_id: test_id_2, tags: [TEST_TAG, TIMESTAMP_TAG, SEARCH_TAG], context: 'stage=new')
       Cloudinary::Uploader.upload(TEST_IMG, public_id: test_id_3, tags: [TEST_TAG, TIMESTAMP_TAG, SEARCH_TAG], context: 'stage=validated')
       sleep(1)
-    end
-
-    around(:each) do |ex|
-      ex.run_with_retry retry: 3
     end
 
     it "should return all images tagged with #{SEARCH_TAG}" do

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -58,7 +58,11 @@ describe Cloudinary::Search do
       Cloudinary::Uploader.upload(TEST_IMG, public_id: test_id_1, tags: [TEST_TAG, TIMESTAMP_TAG, SEARCH_TAG], context: 'stage=in_review')
       Cloudinary::Uploader.upload(TEST_IMG, public_id: test_id_2, tags: [TEST_TAG, TIMESTAMP_TAG, SEARCH_TAG], context: 'stage=new')
       Cloudinary::Uploader.upload(TEST_IMG, public_id: test_id_3, tags: [TEST_TAG, TIMESTAMP_TAG, SEARCH_TAG], context: 'stage=validated')
-      sleep(3)
+      sleep(1)
+    end
+
+    around(:each) do |ex|
+      ex.run_with_retry retry: 3
     end
 
     it "should return all images tagged with #{SEARCH_TAG}" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,10 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run_excluding :delete_all => true
   config.default_sleep_interval = 3 # seconds between failed tests
+
+  config.around(:each, :with_retries) do |ex|
+    ex.run_with_retry retry: 3
+  end
 end
 
 RSpec.shared_context "cleanup" do |tag|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 SUFFIX = ENV['TRAVIS_JOB_ID'] || rand(999999999).to_s
 
 require 'rspec'
+require 'rspec/retry'
 require 'rexml/parsers/ultralightparser'
 require 'nokogiri'
 require 'rspec/version'
@@ -50,6 +51,7 @@ RSpec.configure do |config|
   end
   config.run_all_when_everything_filtered = true
   config.filter_run_excluding :delete_all => true
+  config.default_sleep_interval = 3 # seconds between failed tests
 end
 
 RSpec.shared_context "cleanup" do |tag|

--- a/tools/allocate_test_cloud.sh
+++ b/tools/allocate_test_cloud.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+API_ENDPOINT="https://sub-account-testing.cloudinary.com/create_sub_account"
+
+SDK_NAME="${1}"
+
+CLOUD_DETAILS=$(curl -sS -d "{\"prefix\" : \"${SDK_NAME}\"}" "${API_ENDPOINT}")
+
+echo "${CLOUD_DETAILS}" | ruby -e "require 'json'; c=JSON.parse(ARGF.read)['payload']; puts 'cloudinary://' + c['cloudApiKey'] + ':'+ c['cloudApiSecret'] + '@' + c['cloudName']"

--- a/tools/get_test_cloud.sh
+++ b/tools/get_test_cloud.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+RUBY_VER=$(ruby -v | head -n 1 | cut -d ' ' -f 2);
+SDK_VER=$(grep -oiP '(?<=VERSION = ")([a-zA-Z0-9\-.]+)(?=")' lib/cloudinary/version.rb)
+
+
+bash "${DIR}"/allocate_test_cloud.sh "Ruby ${RUBY_VER} SDK ${SDK_VER}"

--- a/tools/update_version
+++ b/tools/update_version
@@ -12,6 +12,8 @@ QUOTE=
 
 NEW_VERSION=
 
+UPDATE_ONLY=false
+
 function echo_err
 {
     echo "$@" 1>&2;
@@ -23,6 +25,7 @@ function usage
       echo "      -v | --version <version> set a new version"
       echo "      -c | --current show current version"
       echo "      -d | --dry-run print the commands without executing them"
+      echo "      -u | --update-only only update the version"
       echo "      -h | --help print this information and exit"
       echo
       echo "For example: $0 -v 1.2.3"
@@ -30,7 +33,7 @@ function usage
 
 function process_arguments
 {
-    while [ "$1" != "" ]; do
+    while [[ "$1" != "" ]]; do
         case $1 in
             -v | --version )
                 shift
@@ -53,6 +56,11 @@ function process_arguments
                 echo "Dry Run"
                 echo ""
                 ;;
+            -u | --update-only )
+                UPDATE_ONLY=true
+                echo "Only update version"
+                echo ""
+                ;;
             -h | --help )
                 usage; return 0
                 ;;
@@ -72,7 +80,7 @@ function pushd
 # Intentionally make popd silent
 function popd
 {
-    command popd "$@" > /dev/null
+    command popd > /dev/null
 }
 
 # Check if one version is less than or equal than other
@@ -82,7 +90,7 @@ function popd
 # ver_lte 1.2.4 1.2.3 && echo "yes" || echo "no" # no
 function ver_lte
 {
-    [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+    [[ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]]
 }
 
 # Extract the last entry or entry for a given version
@@ -108,6 +116,10 @@ function verify_dependencies
         return 1
     fi
 
+    if [[ "${UPDATE_ONLY}" = true ]]; then
+      return 0;
+    fi
+
     if [[ -z "$(type -t git-changelog)" ]]
     then
         echo_err "git-extras packages is not installed."
@@ -127,25 +139,26 @@ function safe_replace
 
     grep -q "${old}" "${file}" || { echo_err "${old} was not found in ${file}"; return 1; }
 
-    ${CMD_PREFIX} sed -E -i '.bak' "${QUOTE}s/${old}/${new}/${QUOTE}" "${file}"
+    ${CMD_PREFIX} sed -i.bak -e "${QUOTE}s/${old}/${new}/${QUOTE}" -- "${file}"  && rm -- "${file}.bak"
 }
 
 function current_version
 {
-    grep -oiP '(?<=VERSION = ")([0-9.]+[^ ]*)(?=")' lib/cloudinary/version.rb
+    grep -oiP '(?<=VERSION = ")([a-zA-Z0-9\-.]+)(?=")' lib/cloudinary/version.rb
 }
 
 function update_version
 {
-    if [ -z "${NEW_VERSION}" ]; then
+    if [[ -z "${NEW_VERSION}" ]]; then
         usage; return 1
     fi
 
     # Enter git root
     pushd $(git rev-parse --show-toplevel)
+
     local current_version=$(current_version)
 
-    if [ -z "${current_version}" ]; then
+    if [[ -z "${current_version}" ]]; then
         echo_err "Failed getting current version, please check directory structure and/or contact developer"
         return 1
     fi
@@ -166,12 +179,17 @@ function update_version
                   lib/cloudinary/version.rb\
                   || return 1
 
-    ${CMD_PREFIX} git changelog -t ${NEW_VERSION} || true
+    if [[ "${UPDATE_ONLY}" = true ]]; then
+      popd;
+      return 0;
+    fi
+
+    ${CMD_PREFIX} git changelog -t "${NEW_VERSION}" || true
 
     echo ""
     echo "# After editing CHANGELOG.md, optionally review changes and issue these commands:"
     echo git add lib/cloudinary/version.rb CHANGELOG.md
-    echo git commit -m \"Version ${NEW_VERSION}\"
+    echo git commit -m "\"Version ${NEW_VERSION}\""
     echo sed -e "'1,/^${NEW_VERSION//./\\.}/d'" \
              -e "'/^=/d'" \
              -e "'/^$/d'" \
@@ -180,7 +198,7 @@ function update_version
          \| git tag -a "'${NEW_VERSION}'" --file=-
 
     # Don't run those commands on dry run
-    [ -n "${CMD_PREFIX}" ] && { popd; return 0; }
+    [[ -n "${CMD_PREFIX}" ]] && { popd; return 0; }
 
     echo ""
     read -p "Run the above commands automatically? (y/N): " confirm && [[ ${confirm} == [yY] || ${confirm} == [yY][eE][sS] ]] || { popd; return 0; }
@@ -197,6 +215,6 @@ function update_version
     popd
 }
 
+process_arguments "$@"
 verify_dependencies
-process_arguments $*
 update_version


### PR DESCRIPTION
This PR integrates with sub-account test service which allocates clean sub-accounts for travis tests.

It also solves some race conditions in integration tests, by retrying failed integration tests.
By default there are 3 retries with a timeout of 3 seconds between tries.

update_version script is aligned with other SDKs as well.