### PR TITLE
Add download_folder method

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -736,6 +736,18 @@ class Cloudinary::Utils
     download_archive_url(options.merge(:target_format => "zip"))
   end
 
+  # Creates and returns a URL that when invoked creates an archive of a folder.
+  #
+  # @param [Object] folder_path Full path (from the root) of the folder to download.
+  # @param [Hash] options       Additional options.
+  #
+  # @return [String]
+  def self.download_folder(folder_path, options = {})
+    resource_type = options[:resource_type] || "all"
+
+    download_archive_url(options.merge(:resource_type => resource_type, :prefixes => folder_path))
+  end
+
   def self.signed_download_url(public_id, options = {})
     aws_private_key_path = options[:aws_private_key_path] || Cloudinary.config.aws_private_key_path
     if aws_private_key_path
@@ -969,8 +981,7 @@ class Cloudinary::Utils
       :expires_at=>options[:expires_at],
       :transformations => build_eager(options[:transformations]),
       :skip_transformation_name=>Cloudinary::Utils.as_safe_bool(options[:skip_transformation_name]),
-      :allow_missing=>Cloudinary::Utils.as_safe_bool(options[:allow_missing]),
-      :folder_path=>options[:folder_path]
+      :allow_missing=>Cloudinary::Utils.as_safe_bool(options[:allow_missing])
     }
   end
 
@@ -997,22 +1008,7 @@ class Cloudinary::Utils
     Cloudinary::AuthToken.generate options
 
   end
-
-  # Creates and returns a URL that when invoked creates an archive of a folder.
-  #
-  # @param [Object] folder_path Full path (from the root) of the folder to download.
-  # @param [Hash] options       Additional options.
-  #
-  # @return [String]
-  def self.download_folder(folder_path, options = {})
-    options[:resource_type] = options[:resource_type] || "all"
-    options[:prefixes] = folder_path
-
-    cloudinary_params = Cloudinary::Utils.sign_request(Cloudinary::Utils.archive_params(options.merge(:mode => "download")), options)
-
-    return Cloudinary::Utils.cloudinary_api_url("generate_archive", options) + "?" + hash_query_params(cloudinary_params)
-  end
-
+  
   private
 
 

--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -969,7 +969,8 @@ class Cloudinary::Utils
       :expires_at=>options[:expires_at],
       :transformations => build_eager(options[:transformations]),
       :skip_transformation_name=>Cloudinary::Utils.as_safe_bool(options[:skip_transformation_name]),
-      :allow_missing=>Cloudinary::Utils.as_safe_bool(options[:allow_missing])
+      :allow_missing=>Cloudinary::Utils.as_safe_bool(options[:allow_missing]),
+      :folder_path=>options[:folder_path]
     }
   end
 
@@ -996,7 +997,22 @@ class Cloudinary::Utils
     Cloudinary::AuthToken.generate options
 
   end
-  
+
+  # Creates and returns a URL that when invoked creates an archive of a folder.
+  #
+  # @param [Object] folder_path Full path (from the root) of the folder to download.
+  # @param [Hash] options       Additional options.
+  #
+  # @return [String]
+  def self.download_folder(folder_path, options = {})
+    options[:resource_type] = options[:resource_type] || "all"
+    options[:prefixes] = folder_path
+
+    cloudinary_params = Cloudinary::Utils.sign_request(Cloudinary::Utils.archive_params(options.merge(:mode => "download")), options)
+
+    return Cloudinary::Utils.cloudinary_api_url("generate_archive", options) + "?" + hash_query_params(cloudinary_params)
+  end
+
   private
 
 

--- a/spec/archive_spec.rb
+++ b/spec/archive_spec.rb
@@ -142,4 +142,37 @@ describe Cloudinary::Uploader do
       )
     end
   end
+
+  describe "download_folder" do
+    it "should return url with resource_type image" do
+      download_folder_url = Cloudinary::Utils.download_folder("samples/", { :resource_type => "image" })
+
+      expect(download_folder_url).to include("image")
+    end
+
+    it "should return valid url" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/")
+
+      expect(download_folder_url).not_to be_empty
+      expect(download_folder_url).to include("generate_archive")
+    end
+
+    it "should flatten folder" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :flatten_folders => true })
+
+      expect(download_folder_url).to include("flatten_folders")
+    end
+
+    it "should expire_at folder" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :expires_at => Time.now.to_i + 60 })
+
+      expect(download_folder_url).to include("expires_at")
+    end
+
+    it "should use original file_name of folder" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :use_original_filename => true })
+
+      expect(download_folder_url).to include("use_original_filename")
+    end
+  end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1103,4 +1103,37 @@ describe Cloudinary::Utils do
 
   end
   end
+
+  describe "download_folder" do
+    it "should return url with resource_type image" do
+      download_folder_url = Cloudinary::Utils.download_folder("samples/", { :resource_type => "image" })
+
+      expect(download_folder_url).to include("image")
+    end
+
+    it "should return valid url" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/")
+
+      expect(download_folder_url).not_to be_empty
+      expect(download_folder_url).to include("generate_archive")
+    end
+
+    it "should flatten folder" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :flatten_folders => true })
+
+      expect(download_folder_url).to include("flatten_folders")
+    end
+
+    it "should expire_at folder" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :expires_at => Time.now.to_i + 60 })
+
+      expect(download_folder_url).to include("expires_at")
+    end
+
+    it "should use original file_name of folder" do
+      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :use_original_filename => true })
+
+      expect(download_folder_url).to include("use_original_filename")
+    end
+  end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1103,37 +1103,4 @@ describe Cloudinary::Utils do
 
   end
   end
-
-  describe "download_folder" do
-    it "should return url with resource_type image" do
-      download_folder_url = Cloudinary::Utils.download_folder("samples/", { :resource_type => "image" })
-
-      expect(download_folder_url).to include("image")
-    end
-
-    it "should return valid url" do
-      download_folder_url = Cloudinary::Utils.download_folder("folder/")
-
-      expect(download_folder_url).not_to be_empty
-      expect(download_folder_url).to include("generate_archive")
-    end
-
-    it "should flatten folder" do
-      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :flatten_folders => true })
-
-      expect(download_folder_url).to include("flatten_folders")
-    end
-
-    it "should expire_at folder" do
-      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :expires_at => Time.now.to_i + 60 })
-
-      expect(download_folder_url).to include("expires_at")
-    end
-
-    it "should use original file_name of folder" do
-      download_folder_url = Cloudinary::Utils.download_folder("folder/", { :use_original_filename => true })
-
-      expect(download_folder_url).to include("use_original_filename")
-    end
-  end
 end


### PR DESCRIPTION
Add a new method in the Upload API - `download_folder`.

This method creates and returns a URL that when invoked creates an archive of a folder.