### PR TITLE
Add structured metadata to Admin and Upload API

### DIFF
--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -461,7 +461,7 @@ class Cloudinary::Api
 
     params = entries_external_id.each_with_object({:values => [] }) do |item, hash|
       item = only(item, :external_id, :value)
-      hash["values"] << item if item.present?
+      hash[:values ] << item if item.present?
     end
 
     call_metadata_api(:put, uri, params, options)

--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -438,7 +438,7 @@ class Cloudinary::Api
   # @raise [Cloudinary::Api::Error]
   def self.delete_datasource_entries(field_external_id, entries_external_id, options = {})
     uri = [field_external_id, "datasource"]
-    params = { "external_ids" => entries_external_id }
+    params = {:external_ids => entries_external_id }
 
     call_metadata_api(:delete, uri, params, options)
   end
@@ -459,8 +459,8 @@ class Cloudinary::Api
   def self.update_metadata_field_datasource(field_external_id, entries_external_id, options = {})
     uri = [field_external_id, "datasource"]
 
-    params = entries_external_id.each_with_object({ "values" => [] }) do |item, hash|
-      item = only(item, "external_id", "value")
+    params = entries_external_id.each_with_object({:values => [] }) do |item, hash|
+      item = only(item, :external_id, :value)
       hash["values"] << item if item.present?
     end
 
@@ -481,7 +481,7 @@ class Cloudinary::Api
   # @raise [Cloudinary::Api::Error]
   def self.restore_metadata_field_datasource(field_external_id, entries_external_ids, options = {})
     uri = [field_external_id, "datasource_restore"]
-    params = { "external_ids" => entries_external_ids }
+    params = {:external_ids => entries_external_ids }
 
     call_metadata_api(:post, uri, params, options)
   end
@@ -534,10 +534,10 @@ class Cloudinary::Api
     raise GeneralError.new("Error parsing server response (#{response.code}) - #{response.body}. Got - #{e}")
   end
 
-  # Private function that assists with performing an API call to the metadata_fields part of the Admin API.
+  # Protected function that assists with performing an API call to the metadata_fields part of the Admin API.
   #
-  # @private
-  # @param [String] method  The HTTP method. Valid methods: get, post, put, delete
+  # @protected
+  # @param [Symbol] method  The HTTP method. Valid methods: get, post, put, delete
   # @param [Array]  uri     REST endpoint of the API (without 'metadata_fields')
   # @param [Hash]   params  Query/body parameters passed to the method
   # @param [Hash]   options Additional options. Can be an override of the configuration, headers, etc.
@@ -549,8 +549,6 @@ class Cloudinary::Api
 
     call_api(method, uri, params, options)
   end
-
-  private_class_method :call_metadata_api
 
   def self.only(hash, *keys)
     result = {}

--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -348,6 +348,144 @@ class Cloudinary::Api
     call_json_api('GET', json_url, {}, 60, {})
   end
 
+  # Returns a list of all metadata field definitions.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#get_metadata_fields Get metadata fields API reference
+  #
+  # @param [Hash] options Additional options
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.list_metadata_fields(options = {})
+    call_metadata_api(:get, [], {}, options)
+  end
+
+  # Gets a metadata field by external id.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#get_a_metadata_field_by_external_id Get metadata field by external ID API reference
+  #
+  # @param [String] field_external_id The ID of the metadata field to retrieve
+  # @param [Hash]   options           Additional options
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.metadata_field_by_field_id(field_external_id, options = {})
+    uri = [field_external_id]
+
+    call_metadata_api(:get, uri, {}, options)
+  end
+
+  # Creates a new metadata field definition.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field Create metadata field API reference
+  #
+  # @param [Hash] field   The field to add
+  # @param [Hash] options Additional options
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.add_metadata_field(field, options = {})
+    params = only(field, :type, :external_id, :label, :mandatory, :default_value, :validation, :datasource)
+
+    call_metadata_api(:post, [], params, options)
+  end
+
+  # Updates a metadata field by external id.
+  #
+  # Updates a metadata field definition (partially, no need to pass the entire object) passed as JSON data.
+  # See https://cloudinary.com/documentation/admin_api#generic_structure_of_a_metadata_field for the generic structure
+  # of a metadata field.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id Update metadata field API reference
+  #
+  # @param [String] field_external_id The id of the metadata field to update
+  # @param [Hash]   field             The field definition
+  # @param [Hash]   options           Additional options
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.update_metadata_field(field_external_id, field, options = {})
+    uri = [field_external_id]
+    params = only(field, :label, :mandatory, :default_value, :validation)
+
+    call_metadata_api(:put, uri, params, options)
+  end
+
+  # Deletes a metadata field definition.
+  #
+  # The field should no longer be considered a valid candidate for all other endpoints.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#delete_a_metadata_field_by_external_id Delete metadata field API reference
+  #
+  # @param [String] field_external_id The external id of the field to delete
+  # @param [Hash]   options           Additional options
+  # @return [Cloudinary::Api::Response] A hash with a "message" key. "ok" value indicates a successful deletion
+  # @raise [Cloudinary::Api::Error]
+  def self.delete_metadata_field(field_external_id, options = {})
+    uri = [field_external_id]
+
+    call_metadata_api(:delete, uri, {}, options)
+  end
+
+  # Deletes entries in a metadata field datasource.
+  #
+  # Deletes (blocks) the datasource entries for a specified metadata field definition. Sets the state of the
+  # entries to inactive. This is a soft delete, the entries still exist under the hood and can be activated
+  # again with the restore datasource entries method.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#delete_entries_in_a_metadata_field_datasource Delete entries in a metadata field datasource API reference
+  #
+  # @param [String] field_external_id    The id of the field to update
+  # @param [Array]  entries_external_id  The ids of all the entries to delete from the datasource
+  # @param [Hash]   options              Additional options
+  # @return [Cloudinary::Api::Response] The remaining datasource entries
+  # @raise [Cloudinary::Api::Error]
+  def self.delete_datasource_entries(field_external_id, entries_external_id, options = {})
+    uri = [field_external_id, "datasource"]
+    params = { "external_ids" => entries_external_id }
+
+    call_metadata_api(:delete, uri, params, options)
+  end
+
+  # Updates a metadata field datasource.
+  #
+  # Updates the datasource of a supported field type (currently only enum and set), passed as JSON data. The
+  # update is partial: datasource entries with an existing external_id will be updated and entries with new
+  # external_id’s (or without external_id’s) will be appended.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_datasource Update a metadata field datasource API reference
+  #
+  # @param [String] field_external_id   The external id of the field to update
+  # @param [Array]  entries_external_id
+  # @param [Hash]   options             Additional options
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.update_metadata_field_datasource(field_external_id, entries_external_id, options = {})
+    uri = [field_external_id, "datasource"]
+
+    params = entries_external_id.each_with_object({ "values" => [] }) do |item, hash|
+      item = only(item, "external_id", "value")
+      hash["values"] << item if item.present?
+    end
+
+    call_metadata_api(:put, uri, params, options)
+  end
+
+  # Restores entries in a metadata field datasource.
+  #
+  # Restores (unblocks) any previously deleted datasource entries for a specified metadata field definition.
+  # Sets the state of the entries to active.
+  #
+  # @see https://cloudinary.com/documentation/admin_api#restore_entries_in_a_metadata_field_datasource Restore entries in a metadata field datasource API reference
+  #
+  # @param [String] field_external_id    The ID of the metadata field
+  # @param [Array]  entries_external_ids An array of IDs of datasource entries to restore (unblock)
+  # @param [Hash]   options              Additional options
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.restore_metadata_field_datasource(field_external_id, entries_external_ids, options = {})
+    uri = [field_external_id, "datasource_restore"]
+    params = { "external_ids" => entries_external_ids }
+
+    call_metadata_api(:post, uri, params, options)
+  end
+
   protected
 
   def self.call_api(method, uri, params, options)
@@ -395,6 +533,24 @@ class Cloudinary::Api
     # Error is parsing json
     raise GeneralError.new("Error parsing server response (#{response.code}) - #{response.body}. Got - #{e}")
   end
+
+  # Private function that assists with performing an API call to the metadata_fields part of the Admin API.
+  #
+  # @private
+  # @param [String] method  The HTTP method. Valid methods: get, post, put, delete
+  # @param [Array]  uri     REST endpoint of the API (without 'metadata_fields')
+  # @param [Hash]   params  Query/body parameters passed to the method
+  # @param [Hash]   options Additional options. Can be an override of the configuration, headers, etc.
+  # @return [Cloudinary::Api::Response]
+  # @raise [Cloudinary::Api::Error]
+  def self.call_metadata_api(method, uri, params, options)
+    options[:content_type] = :json
+    uri = ["metadata_fields", uri].reject(&:empty?).join("/")
+
+    call_api(method, uri, params, options)
+  end
+
+  private_class_method :call_metadata_api
 
   def self.only(hash, *keys)
     result = {}

--- a/lib/cloudinary/uploader.rb
+++ b/lib/cloudinary/uploader.rb
@@ -65,7 +65,8 @@ class Cloudinary::Uploader
       :unique_filename           => Cloudinary::Utils.as_safe_bool(options[:unique_filename]),
       :upload_preset             => options[:upload_preset],
       :use_filename              => Cloudinary::Utils.as_safe_bool(options[:use_filename]),
-      :accessibility_analysis    => Cloudinary::Utils.as_safe_bool(options[:accessibility_analysis])
+      :accessibility_analysis    => Cloudinary::Utils.as_safe_bool(options[:accessibility_analysis]),
+      :metadata                  => Cloudinary::Utils.encode_context(options[:metadata])
     }
     params
   end
@@ -270,6 +271,29 @@ class Cloudinary::Uploader
 
   def self.remove_all_tags(public_ids = [], options = {})
     return self.call_tags_api(nil, "remove_all", public_ids, options)
+  end
+
+  # Populates metadata fields with the given values. Existing values will be overwritten.
+  #
+  # Any metadata-value pairs given are merged with any existing metadata-value pairs
+  # (an empty value for an existing metadata field clears the value).
+  #
+  # @param [Hash] metadata    A list of custom metadata fields (by external_id) and the values to assign to each of them.
+  # @param [Array] public_ids An array of Public IDs of assets uploaded to Cloudinary.
+  # @param [Hash] options
+  # @option options [String] :resource_type The type of file. Default: image. Valid values: image, raw, video.
+  # @option options [String] :type          The storage type. Default: upload. Valid values: upload, private, authenticated
+  # @return mixed a list of public IDs that were updated
+  # @raise [Cloudinary::Api:Error]
+  def self.update_metadata(metadata, public_ids, options = {})
+    self.call_api("metadata", options) do
+      {
+        timestamp: (options[:timestamp] || Time.now.to_i),
+        type: options[:type],
+        public_ids: Cloudinary::Utils.build_array(public_ids),
+        metadata: Cloudinary::Utils.encode_context(metadata)
+      }
+    end
   end
 
   private

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -1,0 +1,398 @@
+require 'spec_helper'
+require 'cloudinary'
+
+describe 'Metadata' do
+  before(:all) do
+    @id = UNIQUE_TEST_ID
+    @api = Cloudinary::Api
+
+    # External IDs for metadata fields that should be created and later deleted
+    @metadata_fields = []
+    @metadata_fields << @external_id_general = "metadata_external_id_general_#{@id}"
+    @metadata_fields << @external_id_date = "metadata_external_id_date_#{@id}"
+    @metadata_fields << @external_id_enum_2 = "metadata_external_id_enum_2_#{@id}"
+    @metadata_fields << @external_id_set = "metadata_external_id_set_#{@id}"
+    @metadata_fields << @external_id_set_2 = "metadata_external_id_set_2_#{@id}"
+    @metadata_fields << @external_id_set_3 = "metadata_external_id_set_3_#{@id}"
+    @metadata_fields << @external_id_delete_2 = "metadata_deletion_2_#{@id}"
+    @metadata_fields << @external_id_date_validation = "metadata_date_validation_#{@id}"
+    @metadata_fields << @external_id_date_validation_2 = "metadata_date_validation_2_#{@id}"
+    @metadata_fields << @external_id_int_validation = "metadata_int_validation_#{@id}"
+    @metadata_fields << @external_id_int_validation_2 = "metadata_int_validation_2_#{@id}"
+
+     # External IDs for metadata fields that will be accessed through a mock (and should not be deleted or created)
+    @external_id_string = "metadata_external_id_string_#{@id}"
+    @external_id_int = "metadata_external_id_int_#{@id}"
+    @external_id_enum = "metadata_external_id_enum_#{@id}"
+    @external_id_delete = "metadata_deletion_#{@id}"
+
+     # Sample datasource data
+    @datasource_entry_external_id = "metadata_datasource_entry_external_id#{@id}"
+    @datasource_single = [
+      {
+        'value' => 'v1',
+        'external_id' => @datasource_entry_external_id
+      }
+    ]
+
+    @datasource_multiple = [
+      {
+        'value' => 'v2',
+        'external_id' => @datasource_entry_external_id,
+      },
+      {
+        'value' => 'v3'
+      },
+      {
+        'value' => 'v4'
+      },
+    ]
+
+    @metadata_fields_to_create = [
+      {
+        'external_id' => @external_id_general,
+        'type' => 'string'
+      },
+      {
+        'external_id' => @external_id_enum_2,
+        'type' => 'enum',
+        'datasource' => {
+          'values' => @datasource_multiple
+        }
+      },
+      {
+        'external_id' => @external_id_set_2,
+        'type' => 'set',
+        'datasource' => {
+          'values' => @datasource_multiple
+        }
+      },
+      {
+        'external_id' => @external_id_set_3,
+        'type' => 'set',
+        'datasource' => {
+          'values' => @datasource_multiple
+        }
+      },
+      {
+        'external_id' => @external_id_delete_2,
+        'type' => 'integer'
+      }
+    ]
+
+    begin
+      @metadata_fields_to_create.each do |metadata_field_to_create|
+        create_metadata_field_for_test(metadata_field_to_create)
+      end
+    rescue => e
+      raise CloudinaryException, "Exception thrown while adding metadata field in metadata_spec::before(:all) - #{e}"
+    end
+  end
+
+  after(:all) do
+    begin
+      @metadata_fields.each do |metadata_field|
+        @api.delete_metadata_field(metadata_field)
+      end
+    rescue => e
+      # Do nothing. Some exceptions while deleting are expected as we attempt to delete resources that are deleted in
+      # deletion tests (just in case the test fail and they aren't deleted)
+    end
+  end
+
+  # Private helper method to create a metadata field used during testing
+  #
+  # @param [Hash] field The field to add
+  #
+  # @return [Cloudinary::Api::Response]
+  #
+  # @raise [Error]
+  def create_metadata_field_for_test(field)
+    if field['label'].nil?
+      field['label'] = field['external_id']
+    end
+
+    @api.add_metadata_field(field)
+  end
+
+  describe 'list_metadata_fields' do
+    it 'should get a list of all metadata fields' do
+      expected = {
+        :url => /.*\/metadata_fields$/,
+        :method => :get
+      }
+
+      expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
+
+      @api.list_metadata_fields
+    end
+  end
+
+  describe 'metadata_field_by_field_id' do
+    it 'should get a metadata field by external id' do
+      result = @api.metadata_field_by_field_id(@external_id_general)
+
+      expect(result).to be_a_metadata_field('string', 'label' => @external_id_general)
+    end
+  end
+
+  describe 'add_metadata_field' do
+    it 'should create a string metadata field' do
+      field = { 'type' => 'string', 'external_id' => @external_id_string, 'label' => @external_id_string }
+
+      expected = {
+        :url => /.*\/metadata_fields$/,
+        :method => :post,
+        :payload => field.to_json,
+      }
+
+      expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
+
+      @api.add_metadata_field(field)
+    end
+
+    it 'should create an integer metadata field' do
+      field = { 'type' => 'integer', 'external_id' => @external_id_int, 'label' => @external_id_int }
+
+      expected = {
+        :url => /.*\/metadata_fields$/,
+        :method => :post,
+        :payload => field.to_json
+      }
+
+      expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
+
+      @api.add_metadata_field(field)
+    end
+
+    it 'should create a date metadata field' do
+      result = @api.add_metadata_field(
+        'external_id' => @external_id_date,
+        'label' => @external_id_date,
+        'type' => 'date'
+      )
+
+      expect(result).to be_a_metadata_field('date', 'label' => @external_id_date, 'external_id' => @external_id_date, 'mandatory' => false)
+    end
+
+    it 'should create an enum metadata field' do
+      field = {
+        'type' => 'enum',
+        'external_id' => @external_id_enum,
+        'label' => @external_id_enum,
+        'datasource' => {
+          'values' => @datasource_single
+        }
+      }
+      expected = {
+        :url => /.*\/metadata_fields$/,
+        :method => :post,
+        :payload => field.to_json,
+      }
+
+      expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
+
+      @api.add_metadata_field(field)
+    end
+
+    it 'should create a set metadata field' do
+      result = @api.add_metadata_field(
+        'datasource' => {
+          'values' => @datasource_multiple
+        },
+        'external_id' => @external_id_set,
+        'label' => @external_id_set,
+        'type' => 'set'
+      )
+
+      expect(result).to be_a_metadata_field('set', 'label' => @external_id_set, 'external_id' => @external_id_set, 'mandatory' => false)
+    end
+
+    it 'should validate default value of a date field' do
+      past_date = (Date.today - 3).to_s
+      yesterday_date = (Date.today - 1).to_s
+      today_date = (Date.today).to_s
+      future_date = (Date.today + 3).to_s
+
+      last_three_days_validation = {
+        'rules' => [
+          {
+            'type' => 'greater_than',
+            'equals' => false,
+            'value' => past_date
+          },
+          {
+            'type' => 'less_than',
+            'equals' => false,
+            'value' => today_date
+          },
+        ],
+        'type' => 'and'
+      }
+
+      # Test entering a metadata field with date validation and a valid default value
+      metadata_field = {
+        'external_id' => @external_id_date_validation,
+        'label' => @external_id_date_validation,
+        'type' => 'date',
+        'default_value' => yesterday_date,
+        'validation' => last_three_days_validation
+      }
+
+      result = @api.add_metadata_field(metadata_field)
+
+      expect(result).to be_a_metadata_field('date', 'validation' => last_three_days_validation, 'default_value' => metadata_field['default_value'])
+
+      # Test entering a metadata field with date validation and an invalid default value
+      metadata_field = {
+        'external_id' => @external_id_date_validation_2,
+        'label' => @external_id_date_validation_2,
+        'type' => 'date',
+        'default_value' => future_date,
+        'validation' => last_three_days_validation
+      }
+
+      expect {
+        @api.add_metadata_field(metadata_field)
+      }.to raise_error(@api::BadRequest)
+    end
+
+    it 'should validate default value of an integer field' do
+      validation = {
+        'type' => 'less_than',
+        'equals' => true,
+        'value' => 5
+      }
+
+      # Test entering a metadata field with integer validation and a valid default value
+      metadata_field = {
+        'external_id' => @external_id_int_validation,
+        'label' => @external_id_int_validation,
+        'type' => 'integer',
+        'default_value' => 5,
+        'validation' => validation
+      }
+
+      result = @api.add_metadata_field(metadata_field)
+
+      expect(result).to be_a_metadata_field('integer', 'validation' => validation, 'default_value' => metadata_field['default_value'])
+
+      # Test entering a metadata field with integer validation and an invalid default value
+      metadata_field = {
+        'external_id' => @external_id_int_validation_2,
+        'label' => @external_id_int_validation_2,
+        'type' => 'integer',
+        'default_value' => 6,
+        'validation' => validation
+      }
+
+      expect {
+        @api.add_metadata_field(metadata_field)
+      }.to raise_error(@api::BadRequest)
+    end
+  end
+
+  describe 'update_metadata_field' do
+    it 'should update a metadata field by external id' do
+      new_label = "update_metadata_test_new_label#{@external_id_general}"
+      new_default_value = "update_metadata_test_new_default_value#{@external_id_general}"
+
+      # Call the API to update the metadata field
+      # Will also attempt to update some fields that cannot be updated (external_id and type) which will be ignored
+      result = @api.update_metadata_field(
+        @external_id_general,
+        {
+          'external_id' => @external_id_set,
+          'label' => new_label,
+          'type' => 'integer',
+          'mandatory' => true,
+          'default_value' => new_default_value
+        }
+      )
+
+      expect(result).to be_a_metadata_field('string', 'external_id' => @external_id_general, 'label' => new_label, 'default_value' => new_default_value, 'mandatory' => true)
+    end
+  end
+
+  describe 'update_metadata_field_datasource' do
+    it 'should update a metadata field datasource' do
+      result = @api.update_metadata_field_datasource(@external_id_enum_2, @datasource_single)
+
+      expect(result).to be_a_metadata_field_datasource
+      expect(result['values']).to include(@datasource_single[0])
+      expect(@datasource_multiple.count).to eq(result['values'].count)
+      expect(@datasource_single[0]['value']).to eq(result['values'][0]['value'])
+    end
+  end
+
+  describe 'delete_metadata_field' do
+    it 'should delete a metadata field definition by its external id' do
+      expected = {
+        :url => /.*\/metadata_fields\/#{@external_id_delete}$/,
+        :method => :delete,
+        :payload => '{}',
+      }
+
+      expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
+
+      @api.delete_metadata_field(@external_id_delete)
+    end
+
+    it 'should cause subsequent attempts to create a new metadata field with the same external id to fail' do
+      @api.delete_metadata_field(@external_id_delete_2)
+
+      expect {
+        @api.add_metadata_field(
+          'external_id' => @external_id_delete_2,
+          'label' => @external_id_delete_2,
+          'type' => 'integer'
+        )
+      }.to raise_error(@api::BadRequest)
+    end
+  end
+
+  describe 'delete_datasource_entries' do
+    it 'should delete entries in a metadata field datasource' do
+      result = @api.delete_datasource_entries(
+        @external_id_set_2,
+        [
+          @datasource_entry_external_id
+        ]
+      )
+
+      expect(result).to be_a_metadata_field_datasource
+      expect(@datasource_multiple.count - 1).to eq(result['values'].count)
+
+      values = result['values'].map { |datasource_entity| datasource_entity['value'] }
+
+      expect(values).to include(@datasource_multiple[1]['value'])
+      expect(values).to include(@datasource_multiple[2]['value'])
+    end
+  end
+
+  describe 'restore_metadata_field_datasource' do
+    it 'should restore a deleted entry in a metadata field datasource' do
+      # Begin by deleting a datasource entry
+      result = @api.delete_datasource_entries(
+        @external_id_set_3,
+        [
+          @datasource_entry_external_id
+        ]
+      )
+
+      expect(result).to be_a_metadata_field_datasource
+      expect(result['values'].count).to eq(2)
+
+      # Restore datasource entry
+      result = @api.restore_metadata_field_datasource(
+        @external_id_set_3,
+        [
+          @datasource_entry_external_id
+        ]
+      )
+
+      expect(result).to be_a_metadata_field_datasource
+      expect(result['values'].count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
### Brief Summary of Changes
Adds full support for defining, maintaining, and using structured metadata with the Admin and Upload APIs.

#### What does this PR address?
-  New feature
- Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No
