### PR TITLE
Fix options handling issue in SassC

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -438,7 +438,7 @@ begin
     # @return [::SassC::Script::Value::String]
     def cloudinary_url(public_id, sass_options = {})
       options = {}
-      sass_options.to_h.each { |k, v| options[k.value] = v.value }
+      sass_options.to_h.each { |k, v| options[k.value.to_sym] = v.value }
       url = Cloudinary::Utils.cloudinary_url(public_id.value, {:type => :asset}.merge(options))
       ::SassC::Script::Value::String.new("url(#{url})")
     end


### PR DESCRIPTION
### Brief Summary of Changes
SassC options are parsed as a hash with string keys, while `cloudinary_url` uses symbols.
This causes an issue: `:type` cannot be overridden from sass, since we get: `{:type => :asset, "type" => "upload"}`

This PR normalises all keys to symbols.

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[ ] Yes
[x] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
