### PR TITLE
Fix download of a raw file in ActiveStorage

### DIFF
--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -101,6 +101,15 @@ if RUBY_VERSION > '2.2.2'
       expect(url).to end_with(@file_key)
     end
 
+    it "should use correct url for downloading raw file with extension" do
+      @file_key = ActiveStorage::BlobKey.new key: SecureRandom.base58(24), content_type: "application/zip",
+                                             filename: "my_zip.zip"
+      expect(Net::HTTP).to receive(:get_response) do |url|
+        expect(url.to_s).to end_with(@file_key + ".zip")
+      end.and_return(double.as_null_object)
+      @service.download(@file_key)
+    end
+
     it "should use global configuration options" do
       tags = SERVICE_CONFIGURATIONS[:cloudinary][:tags]
       expect(tags).not_to be_empty, "Please set a tags value under cloudinary in #{CONFIGURATION_PATH}"


### PR DESCRIPTION
### Brief Summary of Changes
ActiveStorage integration was not reusing `url` function in the `download` which led to inconsistency. The issue arose with raw files that have a file extension. When uploading a raw file to cloudinary, the public id ends up in a form: public_id.original_extension (since raw files are not transformable), as opposed to images/videos, where public_id is a base name without extension. So, in order to download the file we need to provide both public_id (which is the active storage key) and a file extension that we have from the blob key metadata. 
This PR fixes the inconsistency.

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->

Fixes #420 
