### PR TITLE
Fix resource_type selection in ActiveStorage::Service::CloudinaryService

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -69,7 +69,11 @@ module ActiveStorage
 
     def url_for_direct_upload(key, **options)
       instrument :url, key: key do |payload|
-        options = {:resource_type => resource_type(nil, key)}.merge(@options.merge(options.symbolize_keys))
+        options = @options.merge(options.symbolize_keys)
+        content_type = options[:content_type] || ''
+
+        options[:resource_type] = content_type_to_resource_type(content_type)
+
         options[:public_id] = public_id_internal(key)
         options[:context] = {active_storage_key: key}
         options.delete(:file)

--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -36,6 +36,58 @@ if RUBY_VERSION > '2.2.2'
         url = @service.url_for_direct_upload(key)
         expect(url).to include("context=active_storage_key%3D#{key}")
       end
+
+      it "should set video resource_type for video formats" do
+        key = SecureRandom.base58(24)
+        types = ["video/mp4", "audio/mp3", "application/vnd.apple.mpegurl", "application/x-mpegurl", "application/mpegurl"]
+
+        types.each do |content_type|
+          options = { content_type: content_type }
+
+          url = @service.url_for_direct_upload(key, options)
+
+          expect(url).to include("/video/")
+        end
+      end
+
+      it "should set image resource_type for image formats" do
+        key = SecureRandom.base58(24)
+        types = ["application/pdf", "application/postscript", "image/*"]
+
+        types.each do |content_type|
+          options = { content_type: content_type }
+
+          url = @service.url_for_direct_upload(key, options)
+
+          expect(url).to include("/image/")
+        end
+      end
+
+      it "should set raw resource_type for raw formats" do
+        key = SecureRandom.base58(24)
+        types = ["text/*", "application/*"]
+
+        types.each do |content_type|
+          options = { content_type: content_type }
+
+          url = @service.url_for_direct_upload(key, options)
+
+          expect(url).to include("/raw/")
+        end
+      end
+
+      it "should set image resource_type for other formats" do
+        key = SecureRandom.base58(24)
+        types = ["wordprocessingml.document", "spreadsheetml.sheet"]
+
+        types.each do |content_type|
+          options = { content_type: content_type }
+
+          url = @service.url_for_direct_upload(key, options)
+
+          expect(url).to include("/image/")
+        end
+      end
     end
 
     it "should support uploading to Cloudinary" do


### PR DESCRIPTION
Co-authored-by: Egor Oleynik <egor.slam@gmail.com>

### Brief Summary of Changes
We ran into an issue with the direct upload of NOT images.
Gem is not recognizing resource type and we always get links with `/image/` part.
It works on production. But it is not working in development. 
After investigation, we found the source of the issue. 
It happens because gem using monkey patching for `ActiveStorage::Blob#key`.
We start using content_type from ActiveStorage arguments. ActiveStorage always provides a content type in options for `url_for_direct_upload` method and we can rely on it. [Here is a link to rails source code](https://github.com/rails/rails/blob/92fd1c202bc6cdb945c110b23f9879de0fbd9b0e/activestorage/app/models/active_storage/blob.rb#L134)

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[x] Adds more tests

#### Are tests included?
[X] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
