### PR TITLE
Change test for `eval` upload parameter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ UNIQUE_TEST_FOLDER = "#{TEST_TAG}_#{SUFFIX}_folder"
 NEXT_CURSOR = "db27cfb02b3f69cb39049969c23ca430c6d33d5a3a7c3ad1d870c54e1a54ee0faa5acdd9f6d288666986001711759d10"
 GENERIC_FOLDER_NAME = "some_folder"
 
-EVAL_STR='if (resource_info["width"] < 450) { upload_options["tags"] = "a,b" };
+EVAL_STR='if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true };
           upload_options["context"] = "width=" + resource_info["width"]'
 
 # Auth token

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -88,6 +88,14 @@ describe Cloudinary::Uploader do
     Cloudinary::Uploader.upload(Pathname.new(TEST_IMG), :eval => EVAL_STR)
   end
 
+  it "should execute custom logic in eval upload parameter" do
+    result = Cloudinary::Uploader.upload(Pathname.new(TEST_IMG), :eval => EVAL_STR, :tags => [TEST_TAG, TIMESTAMP_TAG])
+
+    expect(result["context"]["custom"]["width"].to_i).to eq(TEST_IMG_W)
+    expect(result["quality_analysis"]).to be_an_instance_of(Hash)
+    expect(result["quality_analysis"]["focus"]).to be_kind_of(Numeric)
+  end
+
   it "should support the accessibility_analysis of an uploaded image" do
     result = Cloudinary::Uploader.upload(Pathname.new(TEST_IMG), :accessibility_analysis => true, :tags => [TEST_TAG, TIMESTAMP_TAG])
     expect(result).to have_key("accessibility_analysis")


### PR DESCRIPTION
### Brief Summary of Changes

The test for `eval` has a bug that causes it to leave leftover images that aren't deleted during test teardown.

This happens because the current eval test overwrites the tags of the uploaded image, including the tag used in the teardown to delete it.

This PR changes the eval string to test how it does something other than changing tags.

#### What does this PR address?
- [x] Bug fix

#### Are tests included?
- [x] Yes
