### PR TITLE
Added helper function to ensure add on tests do not run by default

### DIFF
--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Helpers::IntegrationTestCaseHelper do
+  before(:all) do
+    @cld_test_addons = ENV["CLD_TEST_ADDONS"]
+  end
+
+  after(:all) do
+    ENV["CLD_TEST_ADDONS"] = @cld_test_addons
+  end
+
+  it "should test add on" do
+    ENV["CLD_TEST_ADDONS"] = nil
+
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_WEBPURIFY)).to eq(false)
+
+    ENV["CLD_TEST_ADDONS"] = "all"
+
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_WEBPURIFY)).to eq(true)
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_JPEGMINI)).to eq(true)
+
+    ENV["CLD_TEST_ADDONS"] = "webpurify"
+
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_WEBPURIFY)).to eq(true)
+
+    ENV["CLD_TEST_ADDONS"] = "webpurify,aspose"
+
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_WEBPURIFY)).to eq(true)
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_ASPOSE)).to eq(true)
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_AZURE)).to eq(false)
+
+    ENV["CLD_TEST_ADDONS"] = "WeBPuRiFY,aSPoSe"
+
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_WEBPURIFY)).to eq(true)
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_ASPOSE)).to eq(true)
+    expect(Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_AZURE)).to eq(false)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,16 @@ RSpec.configure do |config|
   end
 end
 
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    addon_type = example.metadata[:should_test_addon]
+
+    if addon_type && !Helpers::IntegrationTestCaseHelper.should_test_addon(addon_type)
+      skip "Skipping tests for '#{addon_type}'"
+    end
+  end
+end
+
 RSpec.shared_context "cleanup" do |tag|
   tag ||= TEST_TAG
   after :all do

--- a/spec/support/addon_type.rb
+++ b/spec/support/addon_type.rb
@@ -1,0 +1,27 @@
+module Helpers
+  class AddonType
+    ADDON_ALL                         = "all"                       # Test all addons.
+    ADDON_ASPOSE                      = "aspose"                    # Aspose Document Conversion.
+    ADDON_AZURE                       = "azure"                     # Microsoft Azure Video Indexer.
+    ADDON_BG_REMOVAL                  = "bgremoval"                 # Cloudinary AI Background Removal.
+    ADDON_FACIAL_ATTRIBUTES_DETECTION = "facialattributesdetection" # Advanced Facial Sttributes Detection.
+    ADDON_GOOGLE                      = "google"                    # Google AI Video Moderation, Google AI
+                                                                    # Video Transcription, Google Auto Tagging,
+                                                                    # Google Automatic Video Tagging,
+                                                                    # Google Translation.
+    ADDON_IMAGGA                      = "imagga"                    # Imagga Auto Tagging, Crop and Scale.
+    ADDON_JPEGMINI                    = "jpegmini"                  # JPEGmini Image Optimization.
+    ADDON_LIGHTROOM                   = "lightroom"                 # Adobe Photoshop Lightroom (BETA).
+    ADDON_METADEFENDER                = "metadefender"              # MetaDefender Anti-Malware Protection.
+    ADDON_NEURAL_ARTWORK              = "neuralartwork"             # Neural Artwork Style Transfer.
+    ADDON_OBJECT_AWARE_CROPPING       = "objectawarecropping"       # Cloudinary Object-Aware Cropping.
+    ADDON_OCR                         = "ocr"                       # Ocr Text Detection and Extraction.
+    ADDON_PIXELZ                      = "pixelz"                    # Pixelz Remove the Background.
+    ADDON_REKOGNITION                 = "rekognition"               # Amazon Rekognition AI Moderation,
+                                                                    # Amazon Rekognition Auto Tagging,
+                                                                    # Amazon Rekognition Celebrity Detection.
+    ADDON_URL2PNG                     = "url2png"                   # URL2PNG Website Screenshots.
+    ADDON_VIESUS                      = "viesus"                    # VIESUS Automatic Image Enhancement.
+    ADDON_WEBPURIFY                   = "webpurify"                 # WebPurify Image Moderation.
+  end
+end

--- a/spec/support/helpers/integration_test_case_helper.rb
+++ b/spec/support/helpers/integration_test_case_helper.rb
@@ -1,0 +1,18 @@
+module Helpers
+  module IntegrationTestCaseHelper
+    # Should a certain add on be tested?
+    #
+    # @param [String] add_on
+    #
+    # @return [Boolean]
+    def self.should_test_addon(add_on)
+      cld_test_addons = ENV.fetch("CLD_TEST_ADDONS", "").gsub(/\s+/, "").downcase
+
+      if cld_test_addons == AddonType::ADDON_ALL
+        return true
+      end
+
+      cld_test_addons.split(",").include?(add_on)
+    end
+  end
+end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -347,7 +347,7 @@ describe Cloudinary::Uploader do
     expect(result["moderation"][0]["kind"]).to eq("manual")
   end
 
-  it "should support requesting ocr anlysis" do
+  it "should support requesting ocr analysis" do
     expect(RestClient::Request).to receive(:execute) do |options|
       expect(options[:payload][:ocr]).to eq(:adv_ocr)
     end


### PR DESCRIPTION
### Brief Summary of Changes

Added `should_test_addon()` which can be used to determine whether a certain addon should be tested and allow skipping those that shouldn't.

To enable certain addon testing, add its id to the `CLD_TEST_ADDONS` environment variable. Alternatively set `CLD_TEST_ADDONS` to `all` to test all add ons.

This can be used in a test spec like so:

```ruby
it "should support requesting ocr analysis", should_test_addon: Helpers::AddonType::ADDON_OCR do
  expect(something).to be(something)
end
```

Alternatively, it can be used inside a test's code to skip some of it. For example:
```ruby
if Helpers::IntegrationTestCaseHelper.should_test_addon(Helpers::AddonType::ADDON_WEBPURIFY
  # Test addon
end
```

#### What does this PR address?
- [x] New feature

#### Are tests included?
- [x] Yes

#### Reviewer, Please Note:

Consider adding `CLD_TEST_ADDONS=all` to Travis.