### PR TITLE
Fix direct upload of raw files

### DIFF
--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -36,6 +36,12 @@ if RUBY_VERSION > '2.2.2'
         url = @service.url_for_direct_upload(key)
         expect(url).to include("context=active_storage_key%3D#{key}")
       end
+
+      it "should include format for raw file" do
+        key = ActiveStorage::BlobKey.new key: SecureRandom.base58(24), filename: TEST_RAW
+        url = @service.url_for_direct_upload(key, resource_type: "raw")
+        expect(url).to include("format=" + File.extname(TEST_RAW).delete('.'))
+      end
     end
 
     it "should support uploading to Cloudinary" do


### PR DESCRIPTION
### Brief Summary of Changes
 Provide file format for direct upload of raw files, since js client does not include original file name.

 When the file is uploaded from the server, the request includes original filename. That allows Cloudinary
 to identify file extension and append it to the public id of the file (raw files include file extension
 in their public id, opposed to transformable assets (images/video) that use only base name). When uploading
 through direct upload (client side js), filename is missing, and that leads to inconsistent/broken URLs.
 To avoid that, we explicitly pass file format in options.


#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
