### PR TITLE
Allow 'multi' and 'sprite' with urls, add 'download_generated_sprite' and 'download_multi' methods

### DIFF
--- a/lib/cloudinary/uploader.rb
+++ b/lib/cloudinary/uploader.rb
@@ -206,17 +206,17 @@ class Cloudinary::Uploader
     end
   end
 
-  def self.generate_sprite(tag, options={})
+  # Generates sprites by merging multiple images into a single large image.
+  #
+  # @param [Array<String>|String] source Array of urls or a tag
+  # @param [Hash] options Additional options
+  #
+  # @return [Hash] Hash with meta information URLs of generated sprite resources
+  def self.generate_sprite(source, options = {})
     version_store = options.delete(:version_store)
 
     result = call_api("sprite", options) do
-      {
-        :timestamp        => (options[:timestamp] || Time.now.to_i),
-        :tag              => tag,
-        :async            => options[:async],
-        :notification_url => options[:notification_url],
-        :transformation   => Cloudinary::Utils.generate_transformation_string(options.merge(:fetch_format => options[:format]))
-      }
+      Cloudinary::Utils.build_multi_and_sprite_params(source, options)
     end
 
     if version_store == :file && result && result["version"]
@@ -228,16 +228,15 @@ class Cloudinary::Uploader
     return result
   end
 
-  def self.multi(tag, options={})
+  # Creates either a single animated image, video or a PDF.
+  #
+  # @param [Array<String>|String] source Array of urls or a tag
+  # @param [Hash] options Additional options
+  #
+  # @return [Hash] Hash with meta information URLs of the generated file
+  def self.multi(source, options = {})
     call_api("multi", options) do
-      {
-        :timestamp        => (options[:timestamp] || Time.now.to_i),
-        :tag              => tag,
-        :format           => options[:format],
-        :async            => options[:async],
-        :notification_url => options[:notification_url],
-        :transformation   => Cloudinary::Utils.generate_transformation_string(options.clone)
-      }
+      Cloudinary::Utils.build_multi_and_sprite_params(source, options)
     end
   end
 

--- a/lib/cloudinary/uploader.rb
+++ b/lib/cloudinary/uploader.rb
@@ -208,15 +208,15 @@ class Cloudinary::Uploader
 
   # Generates sprites by merging multiple images into a single large image.
   #
-  # @param [Array<String>|String] source Array of urls or a tag
-  # @param [Hash] options Additional options
+  # @param [String|Hash] tag Treated as additional options when hash is passed, otherwise as a tag
+  # @param [Hash] options Additional options. Should be omitted when +tag_or_options+ is a Hash
   #
   # @return [Hash] Hash with meta information URLs of generated sprite resources
-  def self.generate_sprite(source, options = {})
+  def self.generate_sprite(tag, options = {})
     version_store = options.delete(:version_store)
 
     result = call_api("sprite", options) do
-      Cloudinary::Utils.build_multi_and_sprite_params(source, options)
+      Cloudinary::Utils.build_multi_and_sprite_params(tag, options)
     end
 
     if version_store == :file && result && result["version"]
@@ -230,13 +230,13 @@ class Cloudinary::Uploader
 
   # Creates either a single animated image, video or a PDF.
   #
-  # @param [Array<String>|String] source Array of urls or a tag
-  # @param [Hash] options Additional options
+  # @param [String|Hash] tag Treated as additional options when hash is passed, otherwise as a tag
+  # @param [Hash] options Additional options. Should be omitted when +tag_or_options+ is a Hash
   #
   # @return [Hash] Hash with meta information URLs of the generated file
-  def self.multi(source, options = {})
+  def self.multi(tag, options = {})
     call_api("multi", options) do
-      Cloudinary::Utils.build_multi_and_sprite_params(source, options)
+      Cloudinary::Utils.build_multi_and_sprite_params(tag, options)
     end
   end
 

--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -689,36 +689,30 @@ class Cloudinary::Utils
   def self.cloudinary_api_download_url(action, params, options = {})
     cloudinary_params = sign_request(params.merge(mode: MODE_DOWNLOAD), options)
 
-    cloudinary_params = if block_given?
-                          yield cloudinary_params
-                        else
-                          hash_query_params(cloudinary_params)
-                        end
-
-    "#{Cloudinary::Utils.cloudinary_api_url(action, options)}?#{cloudinary_params}"
+    "#{Cloudinary::Utils.cloudinary_api_url(action, options)}?#{hash_query_params(cloudinary_params)}"
   end
   private_class_method :cloudinary_api_download_url
 
   # Return a signed URL to the 'generate_sprite' endpoint with 'mode=download'.
   #
-  # @param [Array<String>|String] source Array of urls or a tag
-  # @param [Hash] options Additional options
+  # @param [String|Hash] tag Treated as additional options when hash is passed, otherwise as a tag
+  # @param [Hash] options Additional options. Should be omitted when +tag_or_options+ is a Hash
   #
   # @return [String] The signed URL to download sprite
-  def self.download_generated_sprite(source, options = {})
-    params = build_multi_and_sprite_params(source, options)
-    cloudinary_api_download_url("sprite", params, options) { |p| flat_hash_to_query_params(p) }
+  def self.download_generated_sprite(tag, options = {})
+    params = build_multi_and_sprite_params(tag, options)
+    cloudinary_api_download_url("sprite", params, options)
   end
 
   # Return a signed URL to the 'multi' endpoint with 'mode=download'.
   #
-  # @param [Array<String>|String] source Array of urls or a tag
-  # @param [Hash] options Additional options
+  # @param [String|Hash] tag Treated as additional options when hash is passed, otherwise as a tag
+  # @param [Hash] options Additional options. Should be omitted when +tag_or_options+ is a Hash
   #
   # @return [String] The signed URL to download multi
-  def self.download_multi(source, options = {})
-    params = build_multi_and_sprite_params(source, options)
-    cloudinary_api_download_url("multi", params, options) { |p| flat_hash_to_query_params(p) }
+  def self.download_multi(tag, options = {})
+    params = build_multi_and_sprite_params(tag, options)
+    cloudinary_api_download_url("multi", params, options)
   end
 
   def self.private_download_url(public_id, format, options = {})
@@ -1194,21 +1188,30 @@ class Cloudinary::Utils
 
   # Build params for multi, download_multi, generate_sprite, and download_generated_sprite methods
   #
-  # @param [Array<String>|String] source Array of urls or a tag
-  # @param [Hash] options Additional options
+  # @param [String|Hash] tag_or_options Treated as additional options when hash is passed, otherwise as a tag
+  # @param [Hash] options Additional options. Should be omitted when +tag_or_options+ is a Hash
   #
   # @return [Hash]
   #
   # @private
-  def self.build_multi_and_sprite_params(source, options)
-    if source.blank?
+  def self.build_multi_and_sprite_params(tag_or_options, options)
+    if tag_or_options.is_a?(Hash)
+      if options.blank?
+        options = tag_or_options
+        tag_or_options = nil
+      else
+        raise "First argument must be a tag when additional options are passed"
+      end
+    end
+    urls = options.delete(:urls)
+
+    if tag_or_options.blank? && urls.blank?
       raise "Either tag or urls are required"
     end
 
-    key = source.is_a?(Array) ? :urls : :tag
-
     {
-      key => source,
+      :tag => tag_or_options,
+      :urls => urls,
       :transformation => Cloudinary::Utils.generate_transformation_string(options.merge(:fetch_format => options[:format])),
       :notification_url => options[:notification_url],
       :format => options[:format],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ UNIQUE_TEST_ID = "#{TEST_TAG}_#{SUFFIX}"
 UNIQUE_TEST_FOLDER = "#{TEST_TAG}_#{SUFFIX}_folder"
 NEXT_CURSOR = "db27cfb02b3f69cb39049969c23ca430c6d33d5a3a7c3ad1d870c54e1a54ee0faa5acdd9f6d288666986001711759d10"
 GENERIC_FOLDER_NAME = "some_folder"
+UPLOADER_TAG = "#{TEST_TAG}_uploader"
 
 EVAL_STR='if (resource_info["width"] < 450) { upload_options["quality_analysis"] = true };
           upload_options["context"] = "width=" + resource_info["width"]'

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -542,7 +542,7 @@ describe Cloudinary::Uploader do
     upload_result2 = Cloudinary::Uploader.upload(TEST_IMAGE_URL, :tags => [sprite_test_tag, TEST_TAG, UPLOADER_TAG, TIMESTAMP_TAG], :public_id => "sprite_test_tag_2#{SUFFIX}")
 
     urls = [upload_result1["url"], upload_result2["url"]]
-    result = Cloudinary::Uploader.generate_sprite(urls, :tags => [TEST_TAG, UPLOADER_TAG])
+    result = Cloudinary::Uploader.generate_sprite(:urls => urls, :tags => [TEST_TAG, UPLOADER_TAG])
     Cloudinary::Api.delete_resources(result["public_id"], :type => "sprite")
     expect(result["image_infos"].count).to eq(2)
 
@@ -568,7 +568,7 @@ describe Cloudinary::Uploader do
 
     urls = [upload_result1["url"], upload_result2["url"]]
 
-    result = Cloudinary::Uploader.multi(urls, :transformation => { :crop => "scale", :width => 0.5 }, tags: [TIMESTAMP_TAG])
+    result = Cloudinary::Uploader.multi(:urls => urls, :transformation => { :crop => "scale", :width => 0.5 }, tags: [TIMESTAMP_TAG])
     Cloudinary::Api.delete_resources(result["public_id"], :type => "multi")
     expect(result["url"]).to end_with(".gif")
     expect(result["url"]).to include("w_0.5")

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1110,12 +1110,12 @@ describe Cloudinary::Utils do
     url2 = "https://res.cloudinary.com/demo/image/upload/car"
 
     url_from_tag = Cloudinary::Utils.download_generated_sprite(sprite_test_tag)
-    url_from_urls = Cloudinary::Utils.download_generated_sprite([url1, url2])
+    url_from_urls = URI.decode(Cloudinary::Utils.download_generated_sprite(:urls => [url1, url2]))
 
     expect(url_from_tag).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/sprite")
     expect(url_from_urls).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/sprite")
-    expect(url_from_urls).to include("urls[]=#{CGI.escape(url1)}")
-    expect(url_from_urls).to include("urls[]=#{CGI.escape(url2)}")
+    expect(url_from_urls).to include("urls[]=#{url1}")
+    expect(url_from_urls).to include("urls[]=#{url2}")
 
     parameters = CGI::parse(url_from_tag)
     expect(parameters["tag"]).to eq([sprite_test_tag])
@@ -1135,12 +1135,12 @@ describe Cloudinary::Utils do
     url2 = "https://res.cloudinary.com/demo/image/upload/car"
 
     url_from_tag = Cloudinary::Utils.download_multi(multi_test_tag)
-    url_from_urls = Cloudinary::Utils.download_multi([url1, url2])
+    url_from_urls = URI.decode(Cloudinary::Utils.download_multi(:urls => [url1, url2]))
 
     expect(url_from_tag).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/multi")
     expect(url_from_urls).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/multi")
-    expect(url_from_urls).to include("urls[]=#{CGI.escape(url1)}")
-    expect(url_from_urls).to include("urls[]=#{CGI.escape(url2)}")
+    expect(url_from_urls).to include("urls[]=#{url1}")
+    expect(url_from_urls).to include("urls[]=#{url2}")
 
     parameters = CGI::parse(url_from_tag)
     expect(parameters["tag"]).to eq([multi_test_tag])

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1103,4 +1103,54 @@ describe Cloudinary::Utils do
 
   end
   end
+
+  it "should download a sprite" do
+    sprite_test_tag = "sprite_tag#{SUFFIX}"
+    url1 = "https://res.cloudinary.com/demo/image/upload/sample"
+    url2 = "https://res.cloudinary.com/demo/image/upload/car"
+
+    url_from_tag = Cloudinary::Utils.download_generated_sprite(sprite_test_tag)
+    url_from_urls = Cloudinary::Utils.download_generated_sprite([url1, url2])
+
+    expect(url_from_tag).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/sprite")
+    expect(url_from_urls).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/sprite")
+    expect(url_from_urls).to include("urls[]=#{CGI.escape(url1)}")
+    expect(url_from_urls).to include("urls[]=#{CGI.escape(url2)}")
+
+    parameters = CGI::parse(url_from_tag)
+    expect(parameters["tag"]).to eq([sprite_test_tag])
+    expect(parameters["mode"]).to eq([Cloudinary::Utils::MODE_DOWNLOAD])
+    expect(parameters["timestamp"]).not_to be_nil
+    expect(parameters["signature"]).not_to be_nil
+
+    parameters = CGI::parse(url_from_urls)
+    expect(parameters["mode"]).to eq([Cloudinary::Utils::MODE_DOWNLOAD])
+    expect(parameters["timestamp"]).not_to be_nil
+    expect(parameters["signature"]).not_to be_nil
+  end
+
+  it "should download multi" do
+    multi_test_tag = "multi_test_tag_#{UNIQUE_TEST_ID}"
+    url1 = "https://res.cloudinary.com/demo/image/upload/sample"
+    url2 = "https://res.cloudinary.com/demo/image/upload/car"
+
+    url_from_tag = Cloudinary::Utils.download_multi(multi_test_tag)
+    url_from_urls = Cloudinary::Utils.download_multi([url1, url2])
+
+    expect(url_from_tag).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/multi")
+    expect(url_from_urls).to start_with("https://api.cloudinary.com/v1_1/#{Cloudinary.config.cloud_name}/image/multi")
+    expect(url_from_urls).to include("urls[]=#{CGI.escape(url1)}")
+    expect(url_from_urls).to include("urls[]=#{CGI.escape(url2)}")
+
+    parameters = CGI::parse(url_from_tag)
+    expect(parameters["tag"]).to eq([multi_test_tag])
+    expect(parameters["mode"]).to eq([Cloudinary::Utils::MODE_DOWNLOAD])
+    expect(parameters["timestamp"]).not_to be_nil
+    expect(parameters["signature"]).not_to be_nil
+
+    parameters = CGI::parse(url_from_urls)
+    expect(parameters["mode"]).to eq([Cloudinary::Utils::MODE_DOWNLOAD])
+    expect(parameters["timestamp"]).not_to be_nil
+    expect(parameters["signature"]).not_to be_nil
+  end
 end


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
Add support for urls list as source for sprites and multi.
#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[x] New feature
[ ] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
