### PR TITLE
Add validation to auth token generation to enforce url or acl in the object

### DIFF
--- a/lib/cloudinary/auth_token.rb
+++ b/lib/cloudinary/auth_token.rb
@@ -33,6 +33,10 @@ module Cloudinary
         end
       end
 
+      if url.blank? && acl.blank?
+        raise 'AuthToken must contain either an acl or a url property'
+      end
+
       token = []
       token << "ip=#{ip}" if ip
       token << "st=#{start}" if start

--- a/spec/auth_token_spec.rb
+++ b/spec/auth_token_spec.rb
@@ -62,6 +62,12 @@ describe 'auth_token' do
       token = { :key => KEY, :expiration => 0, :duration => 0 }
       expect{Cloudinary::Utils.generate_auth_token(token)}.to raise_error(/Must provide either expiration or duration/)
     end
+
+    it "should raise if generate_auth_token is missing acl or url" do
+      expect{Cloudinary::Utils.generate_auth_token(:start_time => 1111111111, :duration => 300)}.to raise_error("AuthToken must contain either an acl or a url property")
+      expect{Cloudinary::Utils.generate_auth_token(:start_time => 1111111111, :duration => 300, :acl => "/*/t_foobar")}.not_to raise_error
+      expect{Cloudinary::Utils.generate_auth_token(:start_time => 1111111111, :duration => 300, :url => "http://res.cloudinary.com/test123/image/upload/v1486020273/sample.jpg")}.not_to raise_error
+    end
   end
   describe "authentication token" do
     it "should generate token string" do


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
Enforce AuthToken to have either acl or urls on new token generation

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No
