### PR TITLE
Fix service delete and exist methods

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -95,7 +95,12 @@ module ActiveStorage
 
     def delete(key)
       instrument :delete, key: key do
-        Cloudinary::Uploader.destroy public_id(key), resource_type: resource_type(nil, key)
+        options = {
+          resource_type: resource_type(nil, key),
+          type: @options[:type]
+        }.compact
+
+        Cloudinary::Uploader.destroy public_id(key), **options
       end
     end
 
@@ -107,7 +112,12 @@ module ActiveStorage
     def exist?(key)
       instrument :exist, key: key do |payload|
         begin
-          Cloudinary::Api.resource public_id(key), resource_type: resource_type(nil, key)
+          options = {
+            resource_type: resource_type(nil, key),
+            type: @options[:type]
+          }.compact
+
+          Cloudinary::Api.resource public_id(key), **options
           true
         rescue Cloudinary::Api::NotFound => e
           false

--- a/spec/active_storage/service/configurations.yml
+++ b/spec/active_storage/service/configurations.yml
@@ -1,5 +1,6 @@
 cloudinary:
   service: Cloudinary
+  type: authenticated
   tags:
     - ActiveStorageTestTag
   folder: active_storage_test_folder


### PR DESCRIPTION
### Brief Summary of Changes
If the service was created with a type parameter other than `upload`, then the deletion does not work.

I added a fix, the tests were not included, since the test file uses 1 service instance(https://github.com/cloudinary/cloudinary_gem/blob/master/spec/active_storage/service/cloudinary_service_spec.rb#L19) with static parameters, I don’t know if it is necessary to create another service additional with a different configuration for tests.

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[ ] Yes
[x] No

#### Reviewer, Please Note:
https://github.com/cloudinary/cloudinary_gem/blob/master/lib/cloudinary/uploader.rb#L145 (by default `upload`)
https://github.com/cloudinary/cloudinary_gem/blob/master/lib/cloudinary/api.rb#L70