### PR TITLE
Fix named transformation with spaces

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -540,7 +540,7 @@ class Cloudinary::Utils
     end
     version &&= "v#{version}"
 
-    transformation = transformation.gsub(%r(([^:])//), '\1/')
+    transformation = transformation.gsub(%r(([^:])//), '\1/').gsub(" ", "%20")
     if sign_url && ( !auth_token || auth_token.empty?)
       raise(CloudinaryException, "Must supply api_secret") if (secret.nil? || secret.empty?)
       to_sign = [transformation, sign_version && version, source_to_sign].reject(&:blank?).join("/")

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -352,6 +352,12 @@ describe Cloudinary::Utils do
               .and empty_options
     end
 
+    it "should support named transformation with spaces" do
+      expect(["test", { :transformation => ["blip blop"] }])
+        .to produce_url("#{upload_path}/t_blip%20blop/test")
+              .and empty_options
+    end
+
     it "should support base transformation" do
       expect(["test", { :transformation => { :x => 100, :y => 100, :crop => :fill }, :crop => :crop, :width => 100 }])
         .to produce_url("#{upload_path}/c_fill,x_100,y_100/c_crop,w_100/test")


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

When generating a delivery URL all the spaces in a named transformation are replaced with with `%20`. 

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[ ] Refactoring
[ ] New feature
[x] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No

