### PR TITLE
Pass transformation in request body rather than in query param

### DIFF
--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -177,24 +177,32 @@ class Cloudinary::Api
   end
 
   def self.transformation(transformation, options={})
-    call_api(:get, "transformations/#{transformation_string(transformation)}", only(options, :next_cursor, :max_results), options)
+    params                  = only(options, :next_cursor, :max_results)
+    params[:transformation] = Cloudinary::Utils.build_eager(transformation)
+    call_api(:get, "transformations", params, options)
   end
 
   def self.delete_transformation(transformation, options={})
-    call_api(:delete, "transformations/#{transformation_string(transformation)}", {}, options)
+    call_api(:delete, "transformations", {:transformation => Cloudinary::Utils.build_eager(transformation)}, options)
   end
 
   # updates - supports:
   #   "allowed_for_strict" boolean
   #   "unsafe_update" transformation params - updates a named transformation parameters without regenerating existing images
   def self.update_transformation(transformation, updates, options={})
-    params                 = only(updates, :allowed_for_strict)
-    params[:unsafe_update] = transformation_string(updates[:unsafe_update]) if updates[:unsafe_update]
-    call_api(:put, "transformations/#{transformation_string(transformation)}", params, options)
+    params                  = only(updates, :allowed_for_strict)
+    params[:unsafe_update]  = Cloudinary::Utils.build_eager(updates[:unsafe_update]) if updates[:unsafe_update]
+    params[:transformation] = Cloudinary::Utils.build_eager(transformation)
+    call_api(:put, "transformations", params, options)
   end
 
   def self.create_transformation(name, definition, options={})
-    call_api(:post, "transformations/#{name}", { :transformation => transformation_string(definition) }, options)
+    params = {
+      :name => name,
+      :transformation => Cloudinary::Utils.build_eager(definition)
+    }
+
+    call_api(:post, "transformations", params, options)
   end
 
   # upload presets

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -377,16 +377,22 @@ describe Cloudinary::Api do
 
       it "should allow deleting named transformation" do
         public_id = "api_test_transformation_#{Time.now.to_i}"
-        expect(RestClient::Request).to receive(:execute).with(deep_hash_value( :url => /.*\/transformations\/#{public_id}/, :method => :delete))
+        expected = {
+          :url => /.*\/transformations$/,
+          :method => :delete,
+          [:payload, :transformation] => public_id
+        }
+        expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
         @api.delete_transformation(public_id)
       end
 
       it "should allow unsafe update of named transformation" do
         public_id = "api_test_transformation_#{Time.now.to_i}"
         expected = {
-            :url => /.*\/transformations\/#{public_id}$/,
+            :url => /.*\/transformations$/,
             :method => :put,
-            [:payload, :unsafe_update] => "c_scale,w_103"}
+            [:payload, :unsafe_update] => "c_scale,w_103",
+            [:payload, :transformation] => public_id}
         expect(RestClient::Request).to receive(:execute).with(deep_hash_value(expected))
         @api.update_transformation(public_id, :unsafe_update => { "crop" => "scale", "width" => 103 })
       end


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
The transformation definition is now passed in body of request instead of as a part of query string

#### What does this PR address?
[ ] Gitub issue (Add reference - #XX)
[x] Refactoring
[ ] New feature
[ ] Bug fix
[ ] Adds more tests

#### Are tests included?
[x] Yes
[ ] No
