### PR TITLE
Update link to new Travis-CI.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/cloudinary/cloudinary_gem.svg?branch=master)](https://travis-ci.org/cloudinary/cloudinary_gem)
+[![Build Status](https://app.travis-ci.com/cloudinary/cloudinary_gem.svg?branch=master)](https://app.travis-ci.com/github/cloudinary/cloudinary_gem)
 Cloudinary
 ==========
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### Brief Summary of Changes

Updates a link for Travis CI.

- Old: https://travis-ci.org/github/cloudinary/cloudinary_gem
- New: https://app.travis-ci.com/github/cloudinary/cloudinary_gem

TRAVIS CI, GMBH shut down `travis-ci.org`.

#### What does this PR address?
- [n/a] GitHub issue (Add reference - #XX)
- [n/a] Refactoring
- [n/a] New feature
- [n/a] Bug fix
- [n/a] Adds more tests
- [x] Docs

#### Are tests included?
- [n/a] Yes
- [n/a] No
- [x] n/a

#### Reviewer, please note:
n/a

#### Checklist:
- [n/a] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation.
- [n/a] I ran the full test suite before pushing the changes and all the tests pass.
