### PR TITLE
Add current Ruby version for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
       rvm: ruby-2.5.9
       before_install:
         - gem install bundler
-  allow_failures:
-    - rvm: 3.0.2
 
 before_script: >
   export CLOUDINARY_URL=$(bash tools/get_test_cloud.sh);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
+dist: focal
 language: ruby
+rvm:
+  - 2.6.7
+  - 2.7.4
+  - 3.0.2
 
 matrix:
   include:
@@ -7,11 +12,13 @@ matrix:
       rvm: 1.9.3
       before_install:
         - gem install bundler -v 1.17.3
-    - name: "Ruby 2.5.3"
+    - name: "Ruby 2.5.9"
       dist: xenial
-      rvm: ruby-2.5.3
+      rvm: ruby-2.5.9
       before_install:
         - gem install bundler
+  allow_failures:
+    - rvm: 3.0.2
 
 before_script: >
   export CLOUDINARY_URL=$(bash tools/get_test_cloud.sh);


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### Brief Summary of Changes
Add current Ruby versions 2.6, 2.7, and 3.0 (with allow_failure) for testing.

#### What does this PR address?
- [x] Adds more tests

#### Are tests included?
- [x] Yes

#### Reviewer, please note:
Actual fix to support Ruby 3.0 is deferred in #468. Merge this first and then move to it.

#### Checklist:
- [x] I ran the full test suite before pushing the changes and all the tests pass.
