### PR TITLE
Configuration: use YAML.safe_load and allowing aliases (for Ruby 3.1)

### DIFF
--- a/lib/cloudinary.rb
+++ b/lib/cloudinary.rb
@@ -145,7 +145,18 @@ module Cloudinary
   #
   # @return [OpenStruct]
   def self.import_settings_from_file
-    OpenStruct.new((YAML.load(ERB.new(IO.read(config_dir.join("cloudinary.yml"))).result)[config_env] rescue {}))
+    yaml_env_config = begin
+      yaml_source = ERB.new(IO.read(config_dir.join("cloudinary.yml"))).result
+      yaml_config = if YAML.respond_to?(:safe_load)
+                      YAML.safe_load(yaml_source, aliases: true)
+                    else
+                      YAML.load(yaml_source)
+                    end
+      yaml_config[config_env]
+    rescue StandardError
+      {}
+    end
+    OpenStruct.new(yaml_env_config)
   end
 
   private_class_method :import_settings_from_file

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -106,5 +106,12 @@ describe Cloudinary do
       expect(Cloudinary::config.api_secret).to eq(API_SECRET)
       expect(Cloudinary::config.oauth_token).to eq(OAUTH_TOKEN)
     end
+
+    it "supports config from Yaml, with aliases and ERB interpolation" do
+      ENV["CLOUDINARY_CONFIG_DIR"] = File.join(File.dirname(__FILE__), 'data')
+      ENV["CLOUDINARY_API_KEY"] = 'api_key'
+      expect(Cloudinary::config.cloud_name).to eq('test_cloud')
+      expect(Cloudinary::config.api_key).to eq('api_key')
+    end
   end
 end

--- a/spec/data/cloudinary.yml
+++ b/spec/data/cloudinary.yml
@@ -1,0 +1,8 @@
+default: &default
+  api_key: '<%= ENV['CLOUDINARY_API_KEY'] %>'
+test:
+  <<: *default
+  cloud_name: test_cloud
+production:
+  <<: *default
+  cloud_name: production_cloud


### PR DESCRIPTION
### Brief Summary of Changes

The goal of this PR is to have YAML aliases supported for the config file in Ruby 3.1

By default, Ruby 3.1 will use `safe_load` so we have to explicitly allow aliases

cf

> Psych 4.0 changes `Psych.load` as `safe_load` by the default. You may need to use Psych 3.3.2 for migrating to this behavior. [[Bug #17866](https://bugs.ruby-lang.org/issues/17866)]

in https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

For example in our project, the `config/cloudinary.yml` file looks like

```yaml
---
default: &default
  api_key: '<%= ENV['CLOUDINARY_API_KEY'] %>'
  api_secret: '<%= ENV['CLOUDINARY_API_SECRET'] %>'
staging: &staging
  <<: *default
  cloud_name: our_test_cloud
development: *staging
test: *staging
production:
  <<: *default
  cloud_name: our_prod_cloud
```
and it's not supported by the current version of the gem

I submitted a similar for another gem, `database_consistency`, that was accepted if you want to have a look: https://github.com/djezzzl/database_consistency/pull/113

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No


#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
