### PR TITLE
Retrieve file after store

### DIFF
--- a/lib/cloudinary/carrier_wave/process.rb
+++ b/lib/cloudinary/carrier_wave/process.rb
@@ -154,8 +154,16 @@ module Cloudinary::CarrierWave
     format = Cloudinary::PreloadedFile.split_format(original_filename || "").last
     return format || "" if resource_type == "raw"
     format = requested_format || format || default_format
- 
+
     format = format.to_s.downcase
     Cloudinary::FORMAT_ALIASES[format] || format
+  end
+
+  def store!(new_file=nil)
+    super
+
+    column = model.send(:_mounter, mounted_as).send(:serialization_column)
+    identifier = model.send(:attribute, column)
+    retrieve_from_store!(identifier) unless identifier.nil?
   end
 end

--- a/spec/carriewave.rb
+++ b/spec/carriewave.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'cloudinary'
+
+module CarrierWave
+  module Storage
+    class Abstract
+      def initialize(uploader)
+        @uploader = uploader
+      end
+
+      attr_accessor :uploader
+    end
+  end
+  class SanitizedFile; end
+end
+
+RSpec.describe Cloudinary::CarrierWave do
+  describe '#store!' do
+    let(:column) { 'example_field' }
+    let(:identifier) { 'identifier' }
+    let(:model) { double(:model, _mounter: mount) }
+    let(:mount) { double(:mount, serialization_column: column) }
+    let(:uploader) { spy(:uploader, model: model, mounted_as: :example).tap { |u| u.extend(Cloudinary::CarrierWave) } }
+
+    subject { uploader.store! }
+
+    it 'triggers `#retrieve_from_store!` after `#store!` executed to populate @file and @identifier' do
+      expect(model).to receive(:attribute).with(column).and_return(identifier)
+      expect(uploader).to receive(:retrieve_from_store!).with(identifier)
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->
Try to fix the problem, that `model.image.file` will be nil even if the file is uploaded.
Calling `retrieve_from_store!` after `store!` called can populate `@file` and `@identifier` variable.
So that will fix this problem.

#### What does this PR address?
- [x] GitHub issue (https://github.com/cloudinary/cloudinary_gem/issues/303)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
