### PR TITLE
Fix escaping of special characters in `public_id`

### DIFF
--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -885,7 +885,7 @@ class Cloudinary::Utils
 
   # Based on CGI::unescape. In addition keeps '+' character as is
   def self.smart_unescape(string)
-    CGI.unescape(string.sub('+', '%2B'))
+    CGI.unescape(string.gsub('+', '%2B'))
   end
 
   def self.random_public_id

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -911,6 +911,7 @@ describe Cloudinary::Utils do
     [
       ["a b", "a%20b"],
       ["a+b", "a%2Bb"],
+      ["a+b+c", "a%2Bb%2Bc"],
       ["a%20b", "a%20b"],
       ["a-b", "a-b"],
       ["a??b", "a%3F%3Fb"],


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
