### PR TITLE
Fix Active Storage Service public id of the raw asset handling

### DIFF
--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -16,8 +16,11 @@ if RUBY_VERSION > '2.2.2'
 
     before :all do
       @key = ActiveStorage::BlobKey.new key: SecureRandom.base58(24), filename: BASENAME
+      @file_key = ActiveStorage::BlobKey.new key: SecureRandom.base58(24), filename: File.basename(TEST_RAW),
+                                            content_type: "application/zip"
       @service = self.class.const_get(:SERVICE)
       @service.upload @key, TEST_IMG_PATH, tags: [TEST_TAG, TIMESTAMP_TAG, AS_TAG]
+      @service.upload @file_key, TEST_RAW_PATH, tags: [TEST_TAG, TIMESTAMP_TAG, AS_TAG]
     end
 
     after :all do
@@ -69,9 +72,18 @@ if RUBY_VERSION > '2.2.2'
       expect(@service.exist?(@key + "nonsense")).to be_falsey
     end
 
+    it "should correctly check if a raw file with extension exists" do
+      expect(@service.exist?(@file_key)).to be_truthy
+    end
+
     it "should delete a resource" do
+      expect(@service.exist?(@key)).to be_truthy
       @service.delete @key
       expect(@service.exist?(@key)).to be_falsey
+
+      expect(@service.exist?(@file_key)).to be_truthy
+      @service.delete @file_key
+      expect(@service.exist?(@file_key)).to be_falsey
     end
 
     it "should fail to delete nonexistent key" do


### PR DESCRIPTION
Fixes #506

### Brief Summary of Changes
This PR fixes issue when raw files with file extension are not deleted, since public id is missing the file extension.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
