### PR TITLE
replace update_all to update_column

### DIFF
--- a/lib/cloudinary/carrier_wave/storage.rb
+++ b/lib/cloudinary/carrier_wave/storage.rb
@@ -82,7 +82,7 @@ class Cloudinary::CarrierWave::Storage < ::CarrierWave::Storage::Abstract
     end
 
     if defined?(ActiveRecord::Base) && uploader.model.is_a?(ActiveRecord::Base)
-      uploader.model.update_column column, name
+      uploader.model.update_column(column, name)
     elsif defined?(Mongoid::Document) && uploader.model.is_a?(Mongoid::Document)
       # Mongoid support
       if Mongoid::VERSION.split(".").first.to_i >= 4

--- a/lib/cloudinary/carrier_wave/storage.rb
+++ b/lib/cloudinary/carrier_wave/storage.rb
@@ -82,14 +82,7 @@ class Cloudinary::CarrierWave::Storage < ::CarrierWave::Storage::Abstract
     end
 
     if defined?(ActiveRecord::Base) && uploader.model.is_a?(ActiveRecord::Base)
-      primary_key = model_class.primary_key.to_sym
-      if defined?(::ActiveRecord::VERSION::MAJOR) && ::ActiveRecord::VERSION::MAJOR > 2
-        model_class.where(primary_key=>uploader.model.send(primary_key)).update_all(column=>name)
-      else
-        # Removed since active record version 3.0.0
-        model_class.update_all({column=>name}, {primary_key=>uploader.model.send(primary_key)})
-      end
-      uploader.model.send :write_attribute, column, name
+      uploader.model.update_column column, name
     elsif defined?(Mongoid::Document) && uploader.model.is_a?(Mongoid::Document)
       # Mongoid support
       if Mongoid::VERSION.split(".").first.to_i >= 4


### PR DESCRIPTION
Using update_all is incompatible with [optimistic locking](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html) and if you attempt to make further updates to the record it fails with ActiveRecord::StaleObjectError

Something like:

```ruby
person = Person.find(1)
person.update!(avatar: '...file...')
person.update!(name: 'Oliver') # this will throw a ActiveRecord::StaleObjectError error
```