### PR TITLE
Avoid early loading of ActionView::Base

### DIFF
--- a/lib/cloudinary/railtie.rb
+++ b/lib/cloudinary/railtie.rb
@@ -3,7 +3,9 @@ class Cloudinary::Railtie < Rails::Railtie
     Dir[File.join(File.dirname(__FILE__),'../tasks/**/*.rake')].each { |f| load f }
   end
   config.after_initialize do |app|
-    ActionView::Base.send :include, CloudinaryHelper
+    ActiveSupport.on_load(:action_view) do
+      ActionView::Base.send :include, CloudinaryHelper
+    end
   end
 
   ActiveSupport.on_load(:action_controller_base) do


### PR DESCRIPTION
### Brief Summary of Changes

The injection of the CloudinaryHelper module can happen lazily when ActionView::Base is loaded by some other code needing it, and there is no reason to trigger the loading early in the railtie.

A consequence of this change is that you can avoid the loading of ActionView::Base altogether in some cases, e.g. if running a specific test that does not need it, or when opening a rails console.

This aligns the behavior with the loading of `Cloudinary::CloudinaryController` which happens lazily too (see [railtie.rb](https://github.com/cloudinary/cloudinary_gem/blob/master/lib/cloudinary/railtie.rb#L9-L11)).

#### What does this PR address?
- [x] GitHub issue (Add reference - #533)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No (railtie not tested)

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
