### PR TITLE
Include contextual metadata when using url_for_direct_upload

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -82,6 +82,7 @@ module ActiveStorage
         # To avoid that, we explicitly pass file format in options.
         options[:format] = ext_for_file(key) if options[:resource_type] == "raw"
         options[:context] = {active_storage_key: key}
+        options[:context].reverse_merge!(options[:extra_context]) if options[:extra_context].is_a?(Hash)
         options.delete(:file)
         payload[:url] = api_uri("upload", options)
       end

--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -83,7 +83,7 @@ module ActiveStorage
         options[:format] = ext_for_file(key) if options[:resource_type] == "raw"
         context = options.delete(:context)
         options[:context] = {active_storage_key: key}
-        options[:context].reverse_merge!(context) if context.is_a?(Hash)
+        options[:context].reverse_merge!(context) if context.respond_to?(:merge)
         options.delete(:file)
         payload[:url] = api_uri("upload", options)
       end

--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -81,8 +81,9 @@ module ActiveStorage
         # through direct upload (client side js), filename is missing, and that leads to inconsistent/broken URLs.
         # To avoid that, we explicitly pass file format in options.
         options[:format] = ext_for_file(key) if options[:resource_type] == "raw"
+        context = options.delete(:context)
         options[:context] = {active_storage_key: key}
-        options[:context].reverse_merge!(options[:extra_context]) if options[:extra_context].is_a?(Hash)
+        options[:context].reverse_merge!(context) if context.is_a?(Hash)
         options.delete(:file)
         payload[:url] = api_uri("upload", options)
       end

--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -43,31 +43,31 @@ if RUBY_VERSION > '2.2.2'
 
       it "should not override the key in the context field" do
         key = SecureRandom.base58(24)
-        url = @service.url_for_direct_upload(key, extra_context: { active_storage_key: "oops" })
+        url = @service.url_for_direct_upload(key, context: { active_storage_key: "oops" })
         expect(url).to include("context=active_storage_key%3D#{key}")
       end
 
       it "should allow the description in a context field" do
         key = SecureRandom.base58(24)
-        url = @service.url_for_direct_upload(key, extra_context: { alt: "yes" })
+        url = @service.url_for_direct_upload(key, context: { alt: "yes" })
         expect(url).to include("context=alt%3Dyes%7Cactive_storage_key%3D#{key}")
       end
 
       it "should allow the caption in a context field" do
         key = SecureRandom.base58(24)
-        url = @service.url_for_direct_upload(key, extra_context: { caption: "yes" })
+        url = @service.url_for_direct_upload(key, context: { caption: "yes" })
         expect(url).to include("context=caption%3Dyes%7Cactive_storage_key%3D#{key}")
       end
 
-      it "should ignore invalid extra_context values" do
+      it "should ignore invalid context values" do
         key = SecureRandom.base58(24)
-        url = @service.url_for_direct_upload(key, extra_context: nil)
+        url = @service.url_for_direct_upload(key, context: nil)
         expect(url).to include("context=active_storage_key%3D#{key}")
       end
 
       it "should allow other context fields" do
         key = SecureRandom.base58(24)
-        url = @service.url_for_direct_upload(key, extra_context: { foo: 123 })
+        url = @service.url_for_direct_upload(key, context: { foo: 123 })
         expect(url).to include("context=foo%3D123%7Cactive_storage_key%3D#{key}")
       end
 

--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -71,6 +71,12 @@ if RUBY_VERSION > '2.2.2'
         expect(url).to include("context=foo%3D123%7Cactive_storage_key%3D#{key}")
       end
 
+      it "should allow ActionController::Parameters" do
+        key = SecureRandom.base58(24)
+        url = @service.url_for_direct_upload(key, context: ActionController::Parameters.new(foo: 123).permit(:foo))
+        expect(url).to include("context=foo%3D123%7Cactive_storage_key%3D#{key}")
+      end
+
       it "should include format for raw file" do
         key = ActiveStorage::BlobKey.new key: SecureRandom.base58(24), filename: TEST_RAW
         url = @service.url_for_direct_upload(key, resource_type: "raw")

--- a/spec/active_storage/service/cloudinary_service_spec.rb
+++ b/spec/active_storage/service/cloudinary_service_spec.rb
@@ -34,10 +34,41 @@ if RUBY_VERSION > '2.2.2'
         expect(url).not_to include(BASENAME)
         expect(url).to include("public_id=#{key}")
       end
+
       it "should include the key in a context field" do
         key = SecureRandom.base58(24)
         url = @service.url_for_direct_upload(key)
         expect(url).to include("context=active_storage_key%3D#{key}")
+      end
+
+      it "should not override the key in the context field" do
+        key = SecureRandom.base58(24)
+        url = @service.url_for_direct_upload(key, extra_context: { active_storage_key: "oops" })
+        expect(url).to include("context=active_storage_key%3D#{key}")
+      end
+
+      it "should allow the description in a context field" do
+        key = SecureRandom.base58(24)
+        url = @service.url_for_direct_upload(key, extra_context: { alt: "yes" })
+        expect(url).to include("context=alt%3Dyes%7Cactive_storage_key%3D#{key}")
+      end
+
+      it "should allow the caption in a context field" do
+        key = SecureRandom.base58(24)
+        url = @service.url_for_direct_upload(key, extra_context: { caption: "yes" })
+        expect(url).to include("context=caption%3Dyes%7Cactive_storage_key%3D#{key}")
+      end
+
+      it "should ignore invalid extra_context values" do
+        key = SecureRandom.base58(24)
+        url = @service.url_for_direct_upload(key, extra_context: nil)
+        expect(url).to include("context=active_storage_key%3D#{key}")
+      end
+
+      it "should allow other context fields" do
+        key = SecureRandom.base58(24)
+        url = @service.url_for_direct_upload(key, extra_context: { foo: 123 })
+        expect(url).to include("context=foo%3D123%7Cactive_storage_key%3D#{key}")
       end
 
       it "should include format for raw file" do


### PR DESCRIPTION
### Brief Summary of Changes

Cloudinary has support for [contextual metadata](https://cloudinary.com/documentation/contextual_metadata) but it doesn't appear to be supported as an option during `ActiveStorage::Service#url_for_direct_upload`. 

I want to send additional context to cloudinary when I generate the URL for direct upload, using active storage.

Example:

```
object.service.url_for_direct_upload(
  object.key,
  ...,
  extra_context: { company: "Rando Co." }
)
```

Creates this on cloudinary:

<img width="490" alt="image" src="https://github.com/cloudinary/cloudinary_gem/assets/191564/3c35948f-20d0-4754-9e15-31ef34b3eb61">

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:

- I picked the `extra_context` key so it wouldn't collide with anything that I might have overlooked. We might be able to just use `context` with a `reverse_merge` of the active storage key and remove the `extra_context` option/key
- Rails 7 has support for [custom_metadata](https://github.com/rails/rails/pull/43294) via a `custom` key in the `metadata` field. 
    - I briefly looked at this but I wasn't comfortable making the larger change to be forward compatible without discussion. 
    - Being able to support both sending structured metadata values & contextual metadata key/value pairs could be very useful. 
    - Storing them in `#metadata[:custom][:structured]` and `#metadata[:custom][:contextual]` makes sense in my head
    - This would allow the local blob metadata to be recorded, but also the remote (at least on create)

#### Checklist:

> I didn't run the full test suite, but tested the file I modified

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
