### PR TITLE
upload_chunked? is removed

### DIFF
--- a/lib/cloudinary/carrier_wave/storage.rb
+++ b/lib/cloudinary/carrier_wave/storage.rb
@@ -36,7 +36,7 @@ class Cloudinary::CarrierWave::Storage < ::CarrierWave::Storage::Abstract
       params[:type]=uploader.class.storage_type
 
       params[:resource_type] ||= :auto
-      upload_method = uploader.upload_chunked? ? "upload_large" : "upload"
+      upload_method = uploader.respond_to?(:upload_chunked?) && uploader.upload_chunked? ? "upload_large" : "upload"
       uploader.metadata = Cloudinary::Uploader.send(upload_method, data, params)
       if uploader.metadata["error"]
         raise Cloudinary::CarrierWave::UploadError.new(uploader.metadata["error"]["message"], uploader.metadata["error"]["http_code"])


### PR DESCRIPTION
This broke for us upgrading to cloudinary v2 i assume this was a legacy setting