### PR TITLE
Add support for `delete_access_key` in Provisioning API

### DIFF
--- a/lib/cloudinary/account_api.rb
+++ b/lib/cloudinary/account_api.rb
@@ -260,6 +260,24 @@ class Cloudinary::AccountApi
     call_account_api(:put, ['sub_accounts', sub_account_id, 'access_keys', api_key], params, options.merge(content_type: :json))
   end
 
+  # Deletes access key.
+  #
+  # @param [String]        sub_account_id  The ID of the sub-account.
+  # @param [String, nil]   api_key         The API key.
+  # @param [String, nil]   name            The display name as shown in the management console.
+  # @param [Object]        options         Additional options.
+  def self.delete_access_key(sub_account_id, api_key = nil, name = nil, options = {})
+    uri = ['sub_accounts', sub_account_id, 'access_keys']
+    unless api_key.blank?
+      uri.append(api_key)
+    end
+
+    params = {
+      name: name,
+    }
+    call_account_api(:delete, uri, params, options.merge(content_type: :json))
+  end
+
   def self.call_account_api(method, uri, params, options)
     account_id = options[:account_id] || Cloudinary.account_config.account_id || raise('Must supply account_id')
     api_key    = options[:provisioning_api_key] || Cloudinary.account_config.provisioning_api_key || raise('Must supply provisioning api_key')

--- a/spec/account_api_spec.rb
+++ b/spec/account_api_spec.rb
@@ -223,5 +223,22 @@ describe Cloudinary::AccountApi do
       expect(updated_key['name']).to eq 'updated_key'
       expect(updated_key['enabled']).to be_truthy
     end
+
+    it "should delete access key" do
+      key_name =  UNIQUE_TEST_ID + "_delete_key"
+      named_key_name = UNIQUE_TEST_ID + "_delete_by_name_key"
+
+      access_key = @api.generate_access_key(cloud_id, key_name)
+      named_access_key = @api.generate_access_key(cloud_id, named_key_name)
+
+      expect(access_key["name"]).to eq key_name
+      expect(named_access_key["name"]).to eq named_key_name
+
+      key_del_res = @api.delete_access_key(cloud_id, access_key["api_key"])
+      expect(key_del_res["message"]).to eq "ok"
+
+      named_key_del_res = @api.delete_access_key(cloud_id, nil, named_key_name)
+      expect(named_key_del_res["message"]).to eq "sok"
+    end
   end
 end


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
