### PR TITLE
Fix Ruby 3.3.5 ostruct warning

### DIFF
--- a/cloudinary.gemspec
+++ b/cloudinary.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday", ">= 2.0.1", "< 3.0.0"
   s.add_dependency "faraday-multipart", "~> 1.0", ">= 1.0.4"
   s.add_dependency 'faraday-follow_redirects', '~> 0.3.0'
+  s.add_dependency "ostruct"
 
   s.add_development_dependency "rails", ">= 6.1.7", "< 8.0.0"
   s.add_development_dependency "rexml", ">= 3.2.5", "< 4.0.0"


### PR DESCRIPTION
The following warning is thrown with Ruby 3.3.5:
```
ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of cloudinary-2.1.2 to request adding ostruct into its gemspec.