### PR TITLE
Add support for `allow_dynamic_list_values` parameter in `MetadataField`

### DIFF
--- a/lib/cloudinary/api.rb
+++ b/lib/cloudinary/api.rb
@@ -1037,9 +1037,7 @@ class Cloudinary::Api
   #
   # @see https://cloudinary.com/documentation/admin_api#create_a_metadata_field
   def self.add_metadata_field(field, options = {})
-    params = only(field, :type, :external_id, :label, :mandatory, :default_value, :validation, :datasource)
-
-    call_metadata_api(:post, [], params, options)
+    call_metadata_api(:post, [], prepare_metadata_field_params(field), options)
   end
 
   # Updates a metadata field by external ID.
@@ -1056,10 +1054,19 @@ class Cloudinary::Api
   #
   # @see https://cloudinary.com/documentation/admin_api#update_a_metadata_field_by_external_id
   def self.update_metadata_field(field_external_id, field, options = {})
-    uri = [field_external_id]
-    params = only(field, :label, :mandatory, :default_value, :validation)
+    uri    = [field_external_id]
 
-    call_metadata_api(:put, uri, params, options)
+    call_metadata_api(:put, uri, prepare_metadata_field_params(field), options)
+  end
+
+  # Prepares optional parameters for add/update_metadata_field API calls.
+  # @param  [Hash]   options Additional options
+  # @return [Object]         Optional parameters
+  def self.prepare_metadata_field_params(field)
+    only(field,
+         :type, :external_id, :label, :mandatory, :restrictions, :default_value, :default_disabled,
+         :validation, :datasource, :allow_dynamic_list_values
+    )
   end
 
   # Deletes a metadata field definition by external ID.

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -543,16 +543,14 @@ describe Cloudinary::Api do
                 [:payload, :name] => "new_preset",
                 [:payload, :folder] => "some_folder",
                 [:payload, :eval] => EVAL_STR,
-                [:payload, :on_success] => ON_SUCCESS_STR,
-                [:payload, :live] => true}
+                [:payload, :on_success] => ON_SUCCESS_STR}
 
 
     res = @mock_api.create_upload_preset(:name       => "new_preset",
                                          :folder     => "some_folder",
                                          :eval       => EVAL_STR,
                                          :on_success => ON_SUCCESS_STR,
-                                         :tags       => [TEST_TAG, TIMESTAMP_TAG],
-                                         :live       => true)
+                                         :tags       => [TEST_TAG, TIMESTAMP_TAG])
     expect(res).to have_deep_hash_values_of(expected)
   end
 
@@ -594,8 +592,7 @@ describe Cloudinary::Api do
                                                              :unsigned => true,
                                                              :disallow_public_id => true,
                                                              :eval => EVAL_STR,
-                                                             :on_success => ON_SUCCESS_STR,
-                                                             :live => true))
+                                                             :on_success => ON_SUCCESS_STR))
     preset = @api.upload_preset(name)
     expect(preset["name"]).to eq(name)
     expect(preset["unsigned"]).to eq(true)
@@ -604,8 +601,7 @@ describe Cloudinary::Api do
                                      "disallow_public_id" => true,
                                      "eval" => EVAL_STR,
                                      "on_success" => ON_SUCCESS_STR,
-                                     "tags" => [TEST_TAG, TIMESTAMP_TAG],
-                                     "live" => true)
+                                     "tags" => [TEST_TAG, TIMESTAMP_TAG])
   end
 
   # this test must be last because it deletes (potentially) all dependent transformations which some tests rely on. Excluded by default.
@@ -740,7 +736,7 @@ describe Cloudinary::Api do
       expect(res).to have_key('settings')
     end
   end
-  
+
   it 'should list assets from an asset folder' do
     expected = { #resources/by_asset_folder
         [:url] => /.*\/resources\/by_asset_folder$/,

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -183,7 +183,8 @@ describe 'Metadata' do
         'label' => @external_id_enum,
         'datasource' => {
           'values' => @datasource_single
-        }
+        },
+        'allow_dynamic_list_values' => true
       }
       expected = {
         :url => /.*\/metadata_fields$/,
@@ -203,10 +204,12 @@ describe 'Metadata' do
         },
         'external_id' => @external_id_set,
         'label' => @external_id_set,
-        'type' => 'set'
+        'type' => 'set',
+        'allow_dynamic_list_values' => true
       )
 
-      expect(result).to be_a_metadata_field('set', 'label' => @external_id_set, 'external_id' => @external_id_set, 'mandatory' => false)
+      expect(result).to be_a_metadata_field('set', 'label' => @external_id_set, 'external_id' => @external_id_set,
+                                            'mandatory' => false, 'allow_dynamic_list_values' => true)
     end
 
     it 'should validate default value of a date field' do


### PR DESCRIPTION
### Brief Summary of Changes
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
