### PR TITLE
Allow passing tag options/attributes for cloudinary_js_config

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -219,14 +219,19 @@ module CloudinaryHelper
   end
 
   CLOUDINARY_JS_CONFIG_PARAMS = [:api_key, :cloud_name, :private_cdn, :secure_distribution, :cdn_subdomain]
-  def cloudinary_js_config
+  def cloudinary_js_config(**tag_options)
     params = {}
     CLOUDINARY_JS_CONFIG_PARAMS.each do
       |param|
       value = Cloudinary.config.send(param)
       params[param] = value if !value.nil?
     end
-    content_tag("script", "$.cloudinary.config(#{params.to_json});".html_safe, :type=>"text/javascript")
+    content_tag(
+      "script",
+      "$.cloudinary.config(#{params.to_json});".html_safe,
+      :type=>"text/javascript",
+      **tag_options
+    )
   end
 
   def cl_client_hints_meta_tag


### PR DESCRIPTION
### Brief Summary of Changes

Adds an optional parameter to the `cloudinary_js_config` helper method to allow passing additional options through to add to the `<script>` tag.

Specifically, this allows passing through a nonce so that the tag can be compatible with a nonce-based `Content-Security-Policy` header, e.g.:

```
<%= cloudinary_js_config nonce: content_security_policy_nonce %>
```

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all the tests pass.
