### PR TITLE
Update faraday-follow_redirects dependency again

### DIFF
--- a/cloudinary.gemspec
+++ b/cloudinary.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "faraday", ">= 2.0.1", "< 3.0.0"
   s.add_dependency "faraday-multipart", "~> 1.0", ">= 1.0.4"
-  s.add_dependency 'faraday-follow_redirects', '~> 0.4.0'
+  s.add_dependency "faraday-follow_redirects", "~> 0.5"
   s.add_dependency "ostruct"
 
   s.add_development_dependency "rails", ">= 6.1.7", "< 8.0.0"


### PR DESCRIPTION
### Brief Summary of Changes
After #587, unfortunately we need to update the faraday-follow_redirects dependency again to be able to use Ruby 4.0, since the [commit that allows Ruby 4.0](https://github.com/tisba/faraday-follow-redirects/commit/3bfb27fb10f40529e0ecfcdf8103903be62e54f2) only landed in 0.5.0

I suggest to change `~> 0.4.0` to `~> 0.5` to allow using the latest 0.x version, similar to the `faraday-multipart` dependency one line above.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
Apart from allowing Ruby 4.0, faraday-follow-redirects did not add any other relevant changes.

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
