### PR TITLE
Add missing stdlib requires (`time`, `base64`, `json`) used by base_api / search / utils

### DIFF
--- a/lib/cloudinary/base_api.rb
+++ b/lib/cloudinary/base_api.rb
@@ -1,5 +1,7 @@
+require "base64"
 require "faraday"
 require "json"
+require "time"
 
 module Cloudinary::BaseApi
   @adapter = nil

--- a/lib/cloudinary/search.rb
+++ b/lib/cloudinary/search.rb
@@ -1,3 +1,6 @@
+require "base64"
+require "json"
+
 class Cloudinary::Search
   ENDPOINT = 'resources'
 

--- a/lib/cloudinary/utils.rb
+++ b/lib/cloudinary/utils.rb
@@ -1,6 +1,7 @@
 # Copyright Cloudinary
 
 # frozen_string_literal: true
+require 'base64'
 require 'digest/sha1'
 require 'zlib'
 require 'uri'


### PR DESCRIPTION
### Brief Summary of Changes

`lib/cloudinary/base_api.rb` uses `Time.parse` and `Base64.urlsafe_encode64`. `lib/cloudinary/utils.rb` uses `Base64.urlsafe_encode64` in several places. `lib/cloudinary/search.rb` calls both `Base64.urlsafe_encode64` and `JSON.generate` from `Search#to_url`. None of those files require the corresponding stdlib at the top. The current test suite happens to preload `time` / `base64` / `json` through `spec_helper` (via Active Storage, Nokogiri and others), which is why CI stays green. In a plain Ruby process — for example on Ruby 4.0 — `require "cloudinary"` itself succeeds but the affected code paths raise `NoMethodError: undefined method 'parse' for class Time` or `NameError: uninitialized constant ...::Base64` / `...::JSON`.

This PR adds the missing `require` lines: `require "time"` and `require "base64"` in `base_api.rb`, `require "base64"` in `utils.rb`, `require "base64"` and `require "json"` in `search.rb`. Same pattern as e2fb1138 ("Add missing `require 'net/http'`"). Pure additive change — `time`, `base64`, and `json` are stdlib on every supported Ruby (`>= 3, < 5`), no behaviour or API change, and the gem still works the same with or without Rails.

Closes #592.

#### What does this PR address?
- [x] GitHub issue (Add reference - #592)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:

* The fix is five `require` statements at the top of three files: `require "time"` and `require "base64"` in `lib/cloudinary/base_api.rb`, `require "base64"` in `lib/cloudinary/utils.rb`, and `require "base64"` and `require "json"` in `lib/cloudinary/search.rb`. They're placed per file (rather than centrally in `lib/cloudinary.rb`) so each file under `autoload` stays self-contained — same approach as e2fb1138.
* No spec is included, mirroring e2fb1138. The existing test suite stays green because `spec_helper` transitively loads these stdlibs anyway; the bug only surfaces in plain-Ruby cold-start, which `bundle exec rspec` doesn't exercise. Happy to add a regression spec (e.g. spawning a child Ruby process per call path) if you'd like one.
* `bundle exec rspec` passes locally. CI on this fork hasn't been triggered yet, so this PR will be the first run of the GitHub Actions matrix (Ruby 3.1.7 / 3.2.9 / 3.3.10 / 3.4.8 / 4.0.0). If maintainer approval is required for Actions on a first-time contributor PR, I'd appreciate it.

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
